### PR TITLE
JsLookupResult enhancements

### DIFF
--- a/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -106,6 +106,14 @@ sealed trait JsLookupResult extends Any with JsReadable {
   def get: JsValue = toOption.get
   def getOrElse(v: => JsValue): JsValue = toOption.getOrElse(v)
 
+  /**
+    * If this result is defined return `this`. Otherwise return `alternative`.
+    */
+  def orElse(alternative: => JsLookupResult): JsLookupResult = this match {
+    case JsDefined(_) => this
+    case JsUndefined() => alternative
+  }
+
   def validate[A](implicit rds: Reads[A]): JsResult[A] = this match {
     case JsDefined(v) => v.validate[A]
     case undef: JsUndefined => JsError(undef.validationError)

--- a/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -112,12 +112,10 @@ sealed trait JsLookupResult extends Any with JsReadable {
   def isDefined: Boolean = !isEmpty
 
   /**
-    * If this result is defined return `this`. Otherwise return `alternative`.
-    */
-  def orElse(alternative: => JsLookupResult): JsLookupResult = this match {
-    case JsDefined(_) => this
-    case JsUndefined() => alternative
-  }
+   * If this result is defined return `this`. Otherwise return `alternative`.
+   */
+  def orElse(alternative: => JsLookupResult): JsLookupResult =
+    if (isDefined) this else alternative
 
   def validate[A](implicit rds: Reads[A]): JsResult[A] = this match {
     case JsDefined(v) => v.validate[A]

--- a/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -105,6 +105,11 @@ sealed trait JsLookupResult extends Any with JsReadable {
   }
   def get: JsValue = toOption.get
   def getOrElse(v: => JsValue): JsValue = toOption.getOrElse(v)
+  def isEmpty: Boolean = this match {
+    case JsUndefined() => true
+    case JsDefined(_) => false
+  }
+  def isDefined: Boolean = !isEmpty
 
   /**
     * If this result is defined return `this`. Otherwise return `alternative`.


### PR DESCRIPTION
Adds three methods to `JsLookupResult` that make working with lookup results a little more pleasant. These are modeled loosely on how `scala.Option` works. While it is true that `isEmpty` and `isDefined` can be accessed by calling `result.toOption.isDefined`, that method does carry a unused object allocation and extra api noise. So I have preferred these methods instead.

1. `isEmpty` = true if the `JsLookupResult` is a `JsUndefined`.
1. `isDefined` = true if the `JsLookupResult` is a `JsDefined`.
1. `orElse` allows alternate lookups to be easily chained if `isEmpty`.

```scala
Welcome to Scala 2.12.0 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_92).
Type in expressions for evaluation. Or try :help.

scala> import play.api.libs.json._
import play.api.libs.json._

scala> val json = Json.obj("a" -> 11, "b" -> "Hi")
json: play.api.libs.json.JsObject = {"a":11,"b":"Hi"}

scala> (json \ "c") orElse (json \ "d") orElse (json \ "b")
res0: play.api.libs.json.JsLookupResult = JsDefined("Hi")
```