### PR TITLE
Fix readNullable on root path (issue #11)

### DIFF
--- a/play-json/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/play-json/src/main/scala/play/api/libs/json/JsPath.scala
@@ -195,7 +195,7 @@ case class JsPath(path: List[PathNode] = List()) {
 
   def applyTillLast(json: JsValue): Either[JsError, JsResult[JsValue]] = {
     def step(path: List[PathNode], json: JsValue): Either[JsError, JsResult[JsValue]] = path match {
-      case Nil => Left(JsError(Seq(this -> Seq(JsonValidationError("error.path.empty")))))
+      case Nil => Right(JsSuccess(json))
       case List(node) => node(json) match {
         case Nil => Right(JsError(Seq(this -> Seq(JsonValidationError("error.path.missing")))))
         case List(js) => Right(JsSuccess(js))

--- a/play-json/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/play-json/src/main/scala/play/api/libs/json/JsPath.scala
@@ -194,6 +194,7 @@ case class JsPath(path: List[PathNode] = List()) {
   }
 
   def applyTillLast(json: JsValue): Either[JsError, JsResult[JsValue]] = {
+    @annotation.tailrec
     def step(path: List[PathNode], json: JsValue): Either[JsError, JsResult[JsValue]] = path match {
       case Nil => Right(JsSuccess(json))
       case List(node) => node(json) match {

--- a/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -261,7 +261,7 @@ class JsonValidSpec extends Specification {
       "readNullables for missing root path fragment" >> {
         implicit val userAddressReads = (
           __.read[User] and
-            __.readNullable[Address]
+          __.readNullable[Address]
         ).tupled
 
         val missingAddressBobby = Json.obj(
@@ -271,7 +271,7 @@ class JsonValidSpec extends Specification {
 
         missingAddressBobby.validate(userAddressReads) must equalTo(
           JsError(__ \ "street", JsonValidationError("error.path.missing")) ++
-          JsError(__ \ "zip", JsonValidationError("error.path.missing"))
+            JsError(__ \ "zip", JsonValidationError("error.path.missing"))
         )
       }
 

--- a/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -176,14 +176,14 @@ class JsonValidSpec extends Specification {
         (json.validate((__ \ "day3").read(Reads.enumNameReads(Weekdays))).asOpt must beNone)
     }
 
-    "Can reads with nullable" in {
+    "read fields with null values" in {
       val json = Json.obj("field" -> JsNull)
 
       val resultPost = json.validate((__ \ "field").read(Reads.optionWithNull[String]))
       resultPost.get must equalTo(None)
     }
 
-    "Validate options using validateOpt" in {
+    "validate options using validateOpt" in {
       val json = Json.obj("foo" -> JsNull, "bar" -> "bar")
 
       (json \ "foo").validateOpt[String] must_== JsSuccess(None)

--- a/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -147,7 +147,7 @@ class JsonValidSpec extends Specification {
         aka("formatted date") must beEqualTo(JsSuccess(c.getTime))
     }
 
-    "validate UUID" in {
+    "validate UUID" >> {
       "validate correct UUIDs" in {
         val uuid = java.util.UUID.randomUUID()
         Json.toJson[java.util.UUID](uuid).validate[java.util.UUID] must beEqualTo(JsSuccess(uuid))
@@ -925,7 +925,7 @@ class JsonValidSpec extends Specification {
       x must equalTo(JsSuccess(42))
     }
 
-    "be a functor" in {
+    "be a functor" >> {
       "JsSuccess" in {
         val res1: JsResult[String] = JsSuccess("foo", JsPath(List(KeyPathNode("bar"))))
         res1.map(identity) must equalTo(res1)

--- a/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -258,6 +258,23 @@ class JsonValidSpec extends Specification {
         )
       }
 
+      "readNullables for missing root path fragment" >> {
+        implicit val userAddressReads = (
+          __.read[User] and
+            __.readNullable[Address]
+        ).tupled
+
+        val missingAddressBobby = Json.obj(
+          "name" -> "bobby",
+          "age" -> 54
+        )
+
+        missingAddressBobby.validate(userAddressReads) must equalTo(
+          JsError(__ \ "street", JsonValidationError("error.path.missing")) ++
+          JsError(__ \ "zip", JsonValidationError("error.path.missing"))
+        )
+      }
+
       "readNullables for badly formed root path" >> {
         implicit val userAddressReads: Reads[(User, Option[Address])] = (
           __.read[User] and

--- a/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -216,7 +216,7 @@ class JsonValidSpec extends Specification {
       JsString("alphabeta").validate[String] must equalTo(JsSuccess("alphabeta"))
     }
 
-    "validate reads on the root path" in {
+    "validate reads on the root path" >> {
       case class Address(street: String, zip: String)
 
       implicit val userReads = (

--- a/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -257,6 +257,34 @@ class JsonValidSpec extends Specification {
           JsSuccess((User("bobby", 54), Some(Address("13 Main St", "98765"))))
         )
       }
+
+      "readNullables for badly formed root path" >> {
+        implicit val userAddressReads: Reads[(User, Option[Address])] = (
+          __.read[User] and
+          __.readNullable[Address]
+        ).tupled
+
+        val missingZipBobby = Json.obj(
+          "name" -> "bobby",
+          "age" -> 54,
+          "street" -> "13 Main St"
+        )
+
+        missingZipBobby.validate(userAddressReads) must equalTo(
+          JsError(__ \ "zip", JsonValidationError("error.path.missing"))
+        )
+      }
+
+      "readNullables for null root path" >> {
+        implicit val userAddressReads = (
+          __.readNullable[User] and
+          __.readNullable[Address]
+        ).tupled
+
+        JsNull.validate(userAddressReads) must equalTo(
+          JsSuccess((None, None))
+        )
+      }
     }
 
     "validate simple constraints" in {


### PR DESCRIPTION
This PR is an attempt at addressing issue #11 .

Prior to this PR, the calling `__.readNullable[T]` would return 'error.path.missing' even when the root object was correctly formed. This commit modifies the code so that it works, at least when the object is present.

With this PR, the following works:

```scala
import play.api.libs.functional.syntax._
import play.api.libs.json._

case class User(name: String, age: Int)
case class Address(street: String, postcode: String)

implicit val readsUser: Reads[User] = (
  (__ \ "name").read[String] and (__ \ "age").read[Int]
)(User)
implicit val readsAddress: Reads[Address] = (
  (__ \ "street").read[String] and (__ \ "postcode").read[String]
)(Address)

implicit val readsUserAddress: Reads[(User, Option[Address])] = (
  __.read[User] and __.readNullable[Address]
).tupled

val sherlockHolmes = Json.obj(
  "name" -> "Sherlock Holmes",
  "age" -> 32,
  "street" -> "221B Baker Street",
  "postcode" -> "NW1 6XE"
)
sherlockHolmes.validate(readsUserAddress)
// (User("Sherlock Holmes", 32), Some(Address("221B Baker Street", "NW1 6XE")))
```

While this works, I'm not sure how to address the case where specific fields are missing. For instance, if `sherlockHolmes` just contains `User` fields:

```
val sherlockHolmes = Json.obj(
  "name" -> "Sherlock Holmes",
  "age" -> 32
)
sherlockHolmes.validate(readsUserAddress)
// JsError(List((/postcode,List(JsonValidationError(List(error.path.missing),WrappedArray()))), (/street,List(JsonValidationError(List(error.path.missing),WrappedArray())))))
```

Is this the behaviour we expect, or should this be `JsSuccess(User(...), None)`?