### PR TITLE
Migrate docs from the Play project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 import interplay.ScalaVersions
 import ReleaseTransformations._
 
@@ -97,7 +101,7 @@ val compatFilters = {
 
 lazy val `play-json` = crossProject.crossType(CrossType.Full)
   .in(file("play-json"))
-  .enablePlugins(PlayLibrary)
+  .enablePlugins(PlayLibrary, Playdoc)
   .settings(commonSettings)
   .settings(
     mimaBinaryIssueFilters ++= {
@@ -118,7 +122,9 @@ lazy val `play-jsonJVM` = `play-json`.jvm.
   settings(
     libraryDependencies ++= joda ++ jacksons ++ specsBuild.map(_ % Test) :+ (
       "ch.qos.logback" % "logback-classic" % "1.1.7" % Test
-    ))
+    ),
+    unmanagedSourceDirectories in Test ++= (baseDirectory.value / ".." / ".." / "docs" / "manual" / "working" / "scalaGuide" ** "code").get
+  )
 
 lazy val `play-jsonJS` = `play-json`.js
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+During the Play JSON build these docs are packaged into a `playdoc`
+JAR file and published. The docs are eventually aggregated together
+with the docs from other Play projects by
+[Omnidoc](https://github.com/playframework/omnidoc).
+
+The packaging and publishing of the docs and running the documentation
+tests is handled by the main `sbt` build at the root of the Play JSON
+project.
+
+There is also a separate `sbt` build configuration included in this
+`docs` directory. This build configuration has been kept separate
+from the main configuration at the root of the Play JSON project in
+order to avoid a circular dependency between Play JSON and the Play
+project's `play-docs-sbt-plugin`.
+
+## How to the `docs` sbt build
+
+You only need to follow these steps if you want to validate the docs
+markdown or view the markdown interactively in a browser. If you just
+want to compile Play JSON and publish its documentation then simply
+run `sbt` at the root of the Play JSON project.
+
+Assuming you want to validate the markdown or view it in a browser,
+here's what you need to do:
+
+1. Build Play JSON by running `sbt +publishLocal` in the root directory
+   of this project.
+
+2. Build the main Play Framework project. This is the second step
+   because Play Framework has a dependency on the Play JSON project.
+
+3. Go to the `docs` directory and run `sbt validateDocs` or `sbt run`.
+   This is the third step because it depends on the
+   `play-docs-sbt-plugin` which is built in the second step.
+
+Voila!

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+lazy val docs = project
+  .in(file("."))
+  .enablePlugins(PlayDocsPlugin)
+  .settings(
+    scalaVersion := "2.12.1",
+    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.0-SNAPSHOT"
+  )

--- a/docs/manual/working/scalaGuide/main/json/ScalaJson.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJson.md
@@ -1,0 +1,186 @@
+<!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+# JSON basics
+
+Modern web applications often need to parse and generate data in the JSON (JavaScript Object Notation) format. Play supports this via its [JSON library](api/libs/json/).
+
+JSON is a lightweight data-interchange format and looks like this:
+
+```json
+{
+  "name" : "Watership Down",
+  "location" : {
+    "lat" : 51.235685,
+    "long" : -1.309197
+  },
+  "residents" : [ {
+    "name" : "Fiver",
+    "age" : 4,
+    "role" : null
+  }, {
+    "name" : "Bigwig",
+    "age" : 6,
+    "role" : "Owsla"
+  } ]
+}
+```
+
+> To learn more about JSON, see [json.org](http://json.org/).
+
+## The Play JSON library
+
+The [`play.api.libs.json`](api/libs/json/) package contains data structures for representing JSON data and utilities for converting between these data structures and other data representations. Some of the features of this package are:
+
+ - [[Automatic conversion|ScalaJsonAutomated]] to and from case classes with minimal boilerplate. If you want to get up and running quickly with minimal code, this is probably the place to start.
+ - [[Custom validation|ScalaJsonCombinators#Validation-with-Reads]] while parsing.
+ - [[Automatic parsing|ScalaBodyParsers#The-default-body-parser]] of JSON in request bodies, with auto-generated errors if content isn't parseable or incorrect Content-type headers are supplied.
+ - Can be used outside of a Play application as a standalone library. Just add `libraryDependencies += "com.typesafe.play" %% "play-json" % playVersion` to your `build.sbt` file.
+ - Highly customizable.
+
+The package provides the following types:
+
+### [`JsValue`](api/libs/json/JsValue.html)
+
+This is a trait representing any JSON value. The JSON library has a case class extending `JsValue` to represent each valid JSON type:
+
+- [`JsString`](api/libs/json/JsString.html)
+- [`JsNumber`](api/libs/json/JsNumber.html)
+- [`JsBoolean`](api/libs/json/JsBoolean.html)
+- [`JsObject`](api/libs/json/JsObject.html)
+- [`JsArray`](api/libs/json/JsArray.html)
+- [`JsNull`](api/libs/json/JsNull$.html)
+
+Using the various `JsValue` types, you can construct a representation of any JSON structure.
+
+### [`Json`](api/libs/json/Json$.html)
+
+The `Json` object provides utilities, primarily for conversion to and from `JsValue` structures.
+
+### [`JsPath`](api/libs/json/JsPath.html)
+
+Represents a path into a `JsValue` structure, analogous to XPath for XML. This is used for traversing `JsValue` structures and in patterns for implicit converters.
+
+## Converting to a `JsValue`
+
+### Using string parsing
+
+@[convert-from-string](code/ScalaJsonSpec.scala)
+
+### Using class construction
+
+@[convert-from-classes](code/ScalaJsonSpec.scala)
+
+`Json.obj` and `Json.arr` can simplify construction a bit. Note that most values don't need to be explicitly wrapped by JsValue classes, the factory methods use implicit conversion (more on this below).
+
+@[convert-from-factory](code/ScalaJsonSpec.scala)
+
+### Using Writes converters
+
+Scala to `JsValue` conversion is performed by the utility method `Json.toJson[T](T)(implicit writes: Writes[T])`. This functionality depends on a converter of type [`Writes[T]`](api/libs/json/Writes.html) which can convert a `T` to a `JsValue`.
+
+The Play JSON API provides implicit `Writes` for most basic types, such as `Int`, `Double`, `String`, and `Boolean`. It also supports `Writes` for collections of any type `T` that a `Writes[T]` exists.
+
+@[convert-from-simple](code/ScalaJsonSpec.scala)
+
+To convert your own models to `JsValue`s, you must define implicit `Writes` converters and provide them in scope.
+
+@[sample-model](code/ScalaJsonSpec.scala)
+
+@[convert-from-model](code/ScalaJsonSpec.scala)
+
+Alternatively, you can define your `Writes` using the combinator pattern:
+
+> Note: The combinator pattern is covered in detail in [[JSON Reads/Writes/Formats Combinators|ScalaJsonCombinators]].
+
+@[convert-from-model-prefwrites](code/ScalaJsonSpec.scala)
+
+## Traversing a JsValue structure
+
+You can traverse a `JsValue` structure and extract specific values. The syntax and functionality is similar to Scala XML processing.
+
+> Note: The following examples are applied to the JsValue structure created in previous examples.
+
+### Simple path `\`
+
+Applying the `\` operator to a `JsValue` will return the property corresponding to the field argument, supposing this is a `JsObject`.
+
+@[traverse-simple-path](code/ScalaJsonSpec.scala)
+
+### Recursive path `\\`
+
+Applying the `\\` operator will do a lookup for the field in the current object and all descendants.
+
+@[traverse-recursive-path](code/ScalaJsonSpec.scala)
+
+### Index lookup (for JsArrays)
+
+You can retrieve a value in a `JsArray` using an apply operator with the index number.
+
+@[traverse-array-index](code/ScalaJsonSpec.scala)
+
+## Converting from a JsValue
+
+### Using String utilities
+
+Minified:
+
+@[convert-to-string](code/ScalaJsonSpec.scala)
+
+```json
+{"name":"Watership Down","location":{"lat":51.235685,"long":-1.309197},"residents":[{"name":"Fiver","age":4,"role":null},{"name":"Bigwig","age":6,"role":"Owsla"}]}
+```
+
+Readable:
+
+@[convert-to-string-pretty](code/ScalaJsonSpec.scala)
+
+```json
+{
+  "name" : "Watership Down",
+  "location" : {
+    "lat" : 51.235685,
+    "long" : -1.309197
+  },
+  "residents" : [ {
+    "name" : "Fiver",
+    "age" : 4,
+    "role" : null
+  }, {
+    "name" : "Bigwig",
+    "age" : 6,
+    "role" : "Owsla"
+  } ]
+}
+```
+
+### Using JsValue.as/asOpt
+
+The simplest way to convert a `JsValue` to another type is using `JsValue.as[T](implicit fjs: Reads[T]): T`. This requires an implicit converter of type [`Reads[T]`](api/libs/json/Reads.html) to convert a `JsValue` to `T` (the inverse of `Writes[T]`). As with `Writes`, the JSON API provides `Reads` for basic types.
+
+@[convert-to-type-as](code/ScalaJsonSpec.scala)
+
+The `as` method will throw a `JsResultException` if the path is not found or the conversion is not possible. A safer method is `JsValue.asOpt[T](implicit fjs: Reads[T]): Option[T]`.
+
+@[convert-to-type-as-opt](code/ScalaJsonSpec.scala)
+
+Although the `asOpt` method is safer, any error information is lost.
+
+### Using validation
+
+The preferred way to convert from a `JsValue` to another type is by using its `validate` method (which takes an argument of type `Reads`). This performs both validation and conversion, returning a type of [`JsResult`](api/libs/json/JsResult.html). `JsResult` is implemented by two classes:
+
+- [`JsSuccess`](api/libs/json/JsSuccess.html): Represents a successful validation/conversion and wraps the result.
+- [`JsError`](api/libs/json/JsError.html): Represents unsuccessful validation/conversion and contains a list of validation errors.
+
+You can apply various patterns for handling a validation result:
+
+@[convert-to-type-validate](code/ScalaJsonSpec.scala)
+
+### JsValue to a model
+
+To convert from JsValue to a model, you must define implicit `Reads[T]` where `T` is the type of your model.
+
+> Note: The pattern used to implement `Reads` and custom validation are covered in detail in [[JSON Reads/Writes/Formats Combinators|ScalaJsonCombinators]].
+
+@[sample-model](code/ScalaJsonSpec.scala)
+
+@[convert-to-model](code/ScalaJsonSpec.scala)

--- a/docs/manual/working/scalaGuide/main/json/ScalaJsonAutomated.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJsonAutomated.md
@@ -1,0 +1,62 @@
+<!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+# JSON automated mapping
+
+If the JSON maps directly to a class, we provide a handy macro so that you don't have to write the `Reads[T]`, `Writes[T]`, or `Format[T]` manually. Given the following case class :
+
+@[model](code/ScalaJsonAutomatedSpec.scala)
+
+The following macro will create a `Reads[Resident]` based on its structure and the name of its fields :
+
+@[auto-reads](code/ScalaJsonAutomatedSpec.scala)
+
+When compiling, the macro will inspect the given class and
+inject the following code, exactly as if you had written it manually :
+
+@[manual-reads](code/ScalaJsonAutomatedSpec.scala)
+
+This is done **at compile-time**, so you don't lose any type safety or performance.
+Similar macros exists for a `Writes[T]` or a `Format[T]` :
+
+@[auto-writes](code/ScalaJsonAutomatedSpec.scala)
+@[auto-format](code/ScalaJsonAutomatedSpec.scala)
+
+So, a complete example of performing automated conversion of a case class to JSON is as follows:
+
+@[auto-case-class-to-JSON](code/ScalaJsonAutomatedSpec.scala)
+
+And a complete example of automatically parsing JSON to a case class is:
+
+@[auto-JSON-to-case-class](code/ScalaJsonAutomatedSpec.scala)
+
+Note: To be able to access JSON from `request.body.asJson`, the request must have a `Content-Type` header of `application/json`. You can relax this constraint by using the [[tolerantJson body parser|ScalaBodyParsers#Choosing-an-explicit-body-parser]].
+
+The above example can be made even more concise by using body parsers with a typed validation function. See the [[savePlaceConcise example|ScalaJsonHttp#Creating-a-new-entity-instance-in-JSON]] in the JSON with HTTP documentation. 
+
+### Requirements
+
+These macros rely on a few assumptions about the type they're working with :
+- It must have a companion object having `apply` and `unapply` methods
+- The return types of the `unapply` must match the argument types of the `apply` method.
+- The parameter names of the `apply` method must be the same as the property names desired in the JSON.
+
+Case classes natively meet these requirements. For more custom classes or traits, you might
+have to implement them.
+
+## Custom Naming Strategies
+
+To use a custom Naming Strategy you need to define a implicit `JsonConfiguration` object and a `JsonNaming`.
+
+Two naming strategies are provided: the default one, using as-is the names of the class properties,
+and the `JsonNaming.SnakeCase` case one.
+
+A strategy other than the default one can be used as following:
+
+@[auto-naming-reads](code/ScalaJsonAutomatedSpec.scala)
+@[auto-naming-writes](code/ScalaJsonAutomatedSpec.scala)
+@[auto-naming-format](code/ScalaJsonAutomatedSpec.scala)
+
+### Implementing your own Naming Strategy
+
+To implement your own Naming Strategy you just need to implement the `JsonNaming` trait:
+
+@[auto-custom-naming-format](code/ScalaJsonAutomatedSpec.scala)

--- a/docs/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
@@ -1,0 +1,123 @@
+<!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+# JSON Reads/Writes/Format Combinators
+
+[[JSON basics|ScalaJson]] introduced [`Reads`](api/libs/json/Reads.html) and [`Writes`](api/libs/json/Writes.html) converters which are used to convert between [`JsValue`](api/libs/json/JsValue.html) structures and other data types. This page covers in greater detail how to build these converters and how to use validation during conversion.
+
+The examples on this page will use this `JsValue` structure and corresponding model:
+
+@[sample-json](code/ScalaJsonCombinatorsSpec.scala)
+
+@[sample-model](code/ScalaJsonCombinatorsSpec.scala)
+
+## JsPath
+
+[`JsPath`](api/libs/json/JsPath.html) is a core building block for creating `Reads`/`Writes`. `JsPath` represents the location of data in a `JsValue` structure. You can use the `JsPath` object (root path) to define a `JsPath` child instance by using syntax similar to traversing `JsValue`:
+
+@[jspath-define](code/ScalaJsonCombinatorsSpec.scala)
+
+The [`play.api.libs.json`](api/libs/json/) package defines an alias for `JsPath`: `__` (double underscore). You can use this if you prefer:
+
+@[jspath-define-alias](code/ScalaJsonCombinatorsSpec.scala)
+
+## Reads
+
+[`Reads`](api/libs/json/Reads.html) converters are used to convert from a `JsValue` to another type. You can combine and nest `Reads` to create more complex `Reads`.
+
+You will require these imports to create `Reads`:
+
+@[reads-imports](code/ScalaJsonCombinatorsSpec.scala)
+
+### Path Reads
+
+`JsPath` has methods to create special `Reads` that apply another `Reads` to a `JsValue` at a specified path:
+
+- `JsPath.read[T](implicit r: Reads[T]): Reads[T]` - Creates a `Reads[T]` that will apply the implicit argument `r` to the `JsValue` at this path.
+- `JsPath.readNullable[T](implicit r: Reads[T]): Reads[Option[T]]` - Use for paths that may be missing or can contain a null value.
+
+> Note: The JSON library provides implicit `Reads` for basic types such as `String`, `Int`, `Double`, etc.
+
+Defining an individual path `Reads` looks like this:
+
+@[reads-simple](code/ScalaJsonCombinatorsSpec.scala)
+
+### Complex Reads
+
+You can combine individual path `Reads` to form more complex `Reads` which can be used to convert to complex models.
+
+For easier understanding, we'll break down the combine functionality into two statements. First combine `Reads` objects using the `and` combinator:
+
+@[reads-complex-builder](code/ScalaJsonCombinatorsSpec.scala)
+
+This will yield a type of `FunctionalBuilder[Reads]#CanBuild2[Double, Double]`. This is an intermediary object and you don't need to worry too much about it, just know that it's used to create a complex `Reads`.
+
+Second call the `apply` method of `CanBuildX` with a function to translate individual values to your model, this will return your complex `Reads`. If you have a case class with a matching constructor signature, you can just use its `apply` method:
+
+@[reads-complex-buildertoreads](code/ScalaJsonCombinatorsSpec.scala)
+
+Here's the same code in a single statement:
+
+@[reads-complex-statement](code/ScalaJsonCombinatorsSpec.scala)
+
+### Validation with Reads
+
+The `JsValue.validate` method was introduced in [[JSON basics|ScalaJson]] as the preferred way to perform validation and conversion from a `JsValue` to another type. Here's the basic pattern:
+
+@[reads-validation-simple](code/ScalaJsonCombinatorsSpec.scala)
+
+Default validation for `Reads` is minimal, such as checking for type conversion errors. You can define custom validation rules by using `Reads` validation helpers. Here are some that are commonly used:
+
+- `Reads.email` - Validates a String has email format.
+- `Reads.minLength(nb)` - Validates the minimum length of a collection or String.
+- `Reads.min` - Validates a minimum value.
+- `Reads.max` - Validates a maximum value.
+- `Reads[A] keepAnd Reads[B] => Reads[A]` - Operator that tries `Reads[A]` and `Reads[B]` but only keeps the result of `Reads[A]` (For those who know Scala parser combinators `keepAnd == <~` ).
+- `Reads[A] andKeep Reads[B] => Reads[B]` - Operator that tries `Reads[A]` and `Reads[B]` but only keeps the result of `Reads[B]` (For those who know Scala parser combinators `andKeep == ~>` ).
+- `Reads[A] or Reads[B] => Reads` - Operator that performs a logical OR and keeps the result of the last `Reads` checked.
+
+To add validation, apply helpers as arguments to the `JsPath.read` method:
+
+@[reads-validation-custom](code/ScalaJsonCombinatorsSpec.scala)
+
+### Putting it all together
+
+By using complex `Reads` and custom validation we can define a set of effective `Reads` for our example model and apply them:
+
+@[reads-model](code/ScalaJsonCombinatorsSpec.scala)
+
+Note that complex `Reads` can be nested. In this case, `placeReads` uses the previously defined implicit `locationReads` and `residentReads` at specific paths in the structure.
+
+## Writes
+
+[`Writes`](api/libs/json/Writes.html) converters are used to convert from some type to a `JsValue`.
+
+You can build complex `Writes` using `JsPath` and combinators very similar to `Reads`. Here's the `Writes` for our example model:
+
+@[writes-model](code/ScalaJsonCombinatorsSpec.scala)
+
+There are a few differences between complex `Writes` and `Reads`:
+
+- The individual path `Writes` are created using the `JsPath.write` method.
+- There is no validation on conversion to `JsValue` which makes the structure simpler and you won't need any validation helpers.
+- The intermediary `FunctionalBuilder#CanBuildX` (created by `and` combinators) takes a function that translates a complex type `T` to a tuple matching the individual path `Writes`. Although this is symmetrical to the `Reads` case, the `unapply` method of a case class returns an `Option` of a tuple of properties and must be used with `unlift` to extract the tuple.
+
+## Recursive Types
+
+One special case that our example model doesn't demonstrate is how to handle `Reads` and `Writes` for recursive types. `JsPath` provides `lazyRead` and `lazyWrite` methods that take call-by-name parameters to handle this:
+
+@[reads-writes-recursive](code/ScalaJsonCombinatorsSpec.scala)
+
+## Format
+
+[`Format[T]`](api/libs/json/Format.html) is just a mix of the `Reads` and `Writes` traits and can be used for implicit conversion in place of its components.
+
+### Creating Format from Reads and Writes
+
+You can define a `Format` by constructing it from `Reads` and `Writes` of the same type:
+
+@[format-components](code/ScalaJsonCombinatorsSpec.scala)
+
+### Creating Format using combinators
+
+In the case where your `Reads` and `Writes` are symmetrical (which may not be the case in real applications), you can define a `Format` directly from combinators:
+
+@[format-combinators](code/ScalaJsonCombinatorsSpec.scala)

--- a/docs/manual/working/scalaGuide/main/json/ScalaJsonTransformers.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJsonTransformers.md
@@ -1,0 +1,554 @@
+<!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+# JSON transformers
+
+> Please note this documentation was initially published as an article by Pascal Voitot ([@mandubian](https://github.com/mandubian)) on [mandubian.com](http://mandubian.com/2012/10/29/unveiling-play-2-dot-1-json-api-part3-json-transformers/)
+
+Now you should know how to validate JSON and convert into any structure you can write in Scala and back to JSON. But as soon as I've begun to use those combinators to write web applications, I almost immediately encountered a case : read JSON from network, validate it and convert it into… JSON. 
+
+## Introducing JSON _coast-to-coast_ design
+
+### Are we doomed to convert JSON to OO?
+
+For a few years now, in almost all web frameworks (except recent JavaScript server side stuff maybe in which JSON is the default data structure), we have been used to get JSON from network and **convert JSON (or even POST/GET data) into OO structures** such as classes (or case classes in Scala). Why?
+
+- For a good reason : **OO structures are "language-native"** and allows **manipulating data with respect to your business logic** in a seamless way while ensuring isolation of business logic from web layers.
+- For a more questionable reason : **ORM frameworks talk to DB only with OO structures** and we have (kind of) convinced ourselves that it was impossible to do else… with the well-known good & bad features of ORMs… (not here to criticize those stuff)
+
+### Is OO conversion really the default use case?
+
+In many cases, you don't really need to perform any real business logic with data but validating/transforming before storing or after extracting. Let's take the CRUD case: 
+
+- You just get the data from the network, validate them a bit and insert/update into DB. 
+- In the other way, you just retrieve data from DB and send them outside.  
+
+So, generally, for CRUD ops, you convert JSON into a OO structure just because the frameworks are only able to speak OO.
+
+> I don't say or pretend you shouldn't use JSON to OO conversion but maybe this is not the most common case and we should keep conversion to OO only when we have real business logic to fulfill.
+
+### New tech players change the way of manipulating JSON
+
+Besides this fact, we have some new DB types such as MongoDB (or CouchDB) accepting document structured data looking almost like JSON trees (_isn't BSON, Binary JSON?_).  
+
+With these DB types, we also have new great tools such as [ReactiveMongo](http://www.reactivemongo.org) which provides reactive environment to stream data to and from Mongo in a very natural way.  
+
+I've been working with Stephane Godbillon to integrate ReactiveMongo with Play2.1 while writing the [Play2-ReactiveMongo module](https://github.com/ReactiveMongo/Play-ReactiveMongo). Besides Mongo facilities for Play2.1, this module provides _Json To/From BSON conversion typeclasses_.  
+
+> So it means you can manipulate JSON flows to and from DB directly without even converting into OO.
+
+### JSON _coast-to-coast_ design
+
+Taking this into account, we can easily imagine the following: 
+
+- Receive JSON.
+- Validate JSON.
+- Transform JSON to fit expected DB document structure.
+- Directly send JSON to DB (or somewhere else).
+
+This is exactly the same case when serving data from DB:
+
+- Extract some data from DB as JSON directly.
+- Filter/transform this JSON to send only mandatory data in the format expected by the client (e.g you don't want some secure info to go out).
+- Directly send JSON to the client.
+
+In this context, we can easily imagine **manipulating a flow of JSON data** from client to DB and back without any (explicit) transformation in anything else than JSON.  
+Naturally, when you plug this transformation flow on **reactive infrastructure provided by Play2.1**, it suddenly opens new horizons.  
+
+> This is the so-called (by me) **JSON coast-to-coast design**: 
+> 
+> - Don't consider JSON data chunk by chunk but as a **continuous flow of data from client to DB (or else) through server**,
+> - Treat the **JSON flow like a pipe that you connect to others pipes** while applying modifications, transformations alongside,
+> - Treat the flow in a **fully asynchronous/non-blocking** way.
+>
+> This is also one of the reason of being of Play2.1 reactive architecture…  
+> I believe **considering your app through the prism of flows of data changes drastically the way you design** your web apps in general. It may also open new functional scopes that fit today's webapps requirements quite better than classic architecture. Anyway, this is not the subject here ;)
+
+So, as you have deduced by yourself, to be able to manipulate Json flows based on validation and transformation directly, we needed some new tools. JSON combinators were good candidates but they are a bit too generic.  
+That's why we have created some specialized combinators and API called **JSON transformers** to do that.
+
+# JSON transformers are `Reads[T <: JsValue]`
+
+- You may tell JSON transformers are just `f:JSON => JSON`.  
+- So a JSON transformer could be simply a `Writes[A <: JsValue]`.  
+- But, a JSON transformer is not only a function: as we said, we also want to validate JSON while transforming it.  
+- As a consequence, a JSON transformer is a `Reads[A <: JsValue]`.
+
+> Keep in mind that a `Reads[A <: JsValue]` is able to transform and not only to read/validate
+
+## Use `JsValue.transform` instead of `JsValue.validate`
+
+We have provided a function helper in `JsValue` to help people consider a `Reads[T]` is a transformer and not only a validator:
+
+`JsValue.transform[A <: JsValue](reads: Reads[A]): JsResult[A]`
+
+This is exactly the same `JsValue.validate(reads)`
+
+## The details
+
+In the code samples below, we’ll use the following JSON:
+
+```json
+{
+  "key1" : "value1",
+  "key2" : {
+    "key21" : 123,
+    "key22" : true,
+    "key23" : [ "alpha", "beta", "gamma"],
+    "key24" : {
+      "key241" : 234.123,
+      "key242" : "value242"
+    }
+  },
+  "key3" : 234
+}
+```
+
+## Case 1: Pick JSON value in JsPath
+
+### Pick value as JsValue
+
+```scala
+import play.api.libs.json._
+
+val jsonTransformer = (__ \ 'key2 \ 'key23).json.pick
+
+scala> json.transform(jsonTransformer)
+res9: play.api.libs.json.JsResult[play.api.libs.json.JsValue] = 
+  JsSuccess(
+    ["alpha","beta","gamma"],
+    /key2/key23
+  )
+```
+
+#### `(__ \ 'key2 \ 'key23).json...`
+
+- All JSON transformers are in `JsPath.json.`
+
+#### `(__ \ 'key2 \ 'key23).json.pick`
+
+- `pick` is a `Reads[JsValue]` which picks the value **IN** the given JsPath. Here `["alpha","beta","gamma"]`
+
+#### `JsSuccess(["alpha","beta","gamma"],/key2/key23)`
+
+- This is a simply successful `JsResult`.
+- For info, `/key2/key23` represents the JsPath where data were read but don't care about it, it's mainly used by Play API to compose `JsResult(s)`).
+- `["alpha","beta","gamma"]` is just due to the fact that we have overridden `toString`.
+
+> **Reminder** 
+> `jsPath.json.pick` gets ONLY the value inside the JsPath
+
+### Pick value as Type
+
+```scala
+import play.api.libs.json._
+
+val jsonTransformer = (__ \ 'key2 \ 'key23).json.pick[JsArray]
+
+scala> json.transform(jsonTransformer)
+res10: play.api.libs.json.JsResult[play.api.libs.json.JsArray] = 
+  JsSuccess(
+    ["alpha","beta","gamma"],
+    /key2/key23
+  )
+```
+
+#### `(__ \ 'key2 \ 'key23).json.pick[JsArray]` 
+
+- `pick[T]` is a `Reads[T <: JsValue]` which picks the value (as a `JsArray` in our case) **IN** the given `JsPath`
+
+> **Reminder**
+> `jsPath.json.pick[T <: JsValue]` extracts ONLY the typed value inside the `JsPath`
+
+## Case 2: Pick branch following `JsPath`
+
+### Pick branch as `JsValue`
+
+```scala
+import play.api.libs.json._
+
+val jsonTransformer = (__ \ 'key2 \ 'key24 \ 'key241).json.pickBranch
+
+scala> json.transform(jsonTransformer)
+res11: play.api.libs.json.JsResult[play.api.libs.json.JsObject] = 
+  JsSuccess(
+  {
+    "key2": {
+      "key24":{
+        "key241":234.123
+      }
+    }
+  },
+  /key2/key24/key241
+  )
+```
+
+#### `(__ \ 'key2 \ 'key23).json.pickBranch`
+ 
+- `pickBranch` is a `Reads[JsValue]` which picks the branch from root to given `JsPath`
+
+#### `{"key2":{"key24":{"key242":"value242"}}}`
+
+- The result is the branch from root to given JsPath including the JsValue in `JsPath`
+
+> **Reminder:**
+> `jsPath.json.pickBranch` extracts the single branch down to JsPath + the value inside JsPath
+
+
+## Case 3: Copy a value from input JsPath into a new JsPath
+
+```scala
+import play.api.libs.json._
+
+val jsonTransformer = (__ \ 'key25 \ 'key251).json.copyFrom( (__ \ 'key2 \ 'key21).json.pick )
+
+scala> json.transform(jsonTransformer)
+res12: play.api.libs.json.JsResult[play.api.libs.json.JsObject] 
+  JsSuccess( 
+    {
+      "key25":{
+        "key251":123
+      }
+    },
+    /key2/key21
+  )
+
+```
+
+#### `(__ \ 'key25 \ 'key251).json.copyFrom( reads: Reads[A <: JsValue] )`
+ 
+- `copyFrom` is a `Reads[JsValue]`
+- `copyFrom` reads the JsValue from input JSON using provided Reads[A]
+- `copyFrom` copies this extracted JsValue as the leaf of a new branch corresponding to given JsPath
+  
+####`{"key25":{"key251":123}}`
+
+- `copyFrom` reads value `123` 
+- `copyFrom` copies this value into new branch `(__ \ 'key25 \ 'key251)`
+
+> **Reminder:**
+> `jsPath.json.copyFrom(Reads[A <: JsValue])` reads value from input JSON and creates a new branch with result as leaf
+
+## Case 4: Copy full input Json & update a branch
+
+```scala
+import play.api.libs.json._
+
+val jsonTransformer = (__ \ 'key2 \ 'key24).json.update( 
+  __.read[JsObject].map{ o => o ++ Json.obj( "field243" -> "coucou" ) }
+)
+
+scala> json.transform(jsonTransformer)
+res13: play.api.libs.json.JsResult[play.api.libs.json.JsObject] = 
+  JsSuccess(
+    {
+      "key1":"value1",
+      "key2":{
+        "key21":123,
+        "key22":true,
+        "key23":["alpha","beta","gamma"],
+        "key24":{
+          "key241":234.123,
+          "key242":"value242",
+          "field243":"coucou"
+        }
+      },
+      "key3":234
+    },
+  )
+
+```
+
+####`(__ \ 'key2).json.update(reads: Reads[A < JsValue])`
+
+- Is a `Reads[JsObject]`
+
+####`(__ \ 'key2 \ 'key24).json.update(reads)` does 3 things:
+
+- Extracts value from input JSON at JsPath `(__ \ 'key2 \ 'key24)`.
+- Applies `reads` on this relative value and re-creates a branch `(__ \ 'key2 \ 'key24)` adding result of `reads` as leaf.
+- Merges this branch with full input JSON replacing existing branch (so it works only with input `JsObject` and not other type of `JsValue`).
+
+####`JsSuccess({…},)`
+
+- Just for info, there is no JsPath as 2nd parameter there because the JSON manipulation was done from Root JsPath
+
+> **Reminder:**
+> `jsPath.json.update(Reads[A <: JsValue])` only works for `JsObject`, copies full input `JsObject` and updates jsPath with provided `Reads[A <: JsValue]`
+
+## Case 5: Put a given value in a new branch
+
+```scala
+import play.api.libs.json._
+
+val jsonTransformer = (__ \ 'key24 \ 'key241).json.put(JsNumber(456))
+
+scala> json.transform(jsonTransformer)
+res14: play.api.libs.json.JsResult[play.api.libs.json.JsObject] = 
+  JsSuccess(
+    {
+      "key24":{
+        "key241":456
+      }
+    },
+  )
+
+```
+
+####`(__ \ 'key24 \ 'key241).json.put( a: => JsValue )`
+
+- Is a Reads[JsObject]
+
+####`(__ \ 'key24 \ 'key241).json.put( a: => JsValue )`
+
+- Creates a new branch `(__ \ 'key24 \ 'key241)`
+- Puts `a` as leaf of this branch.
+
+####`jsPath.json.put( a: => JsValue )`
+
+- Takes a `JsValue` argument passed by name allowing to pass even a closure to it.
+
+####`jsPath.json.put`
+
+- Does not care at all about input JSON.
+- Simply replace input JSON by given value.
+
+> **Reminder: **
+> `jsPath.json.put( a: => Jsvalue )` creates a new branch with a given value without taking into account input JSON
+
+## Case 6: Prune a branch from input JSON
+
+```scala
+import play.api.libs.json._
+
+val jsonTransformer = (__ \ 'key2 \ 'key22).json.prune
+
+scala> json.transform(jsonTransformer)
+res15: play.api.libs.json.JsResult[play.api.libs.json.JsObject] = 
+  JsSuccess(
+    {
+      "key1":"value1",
+      "key3":234,
+      "key2":{
+        "key21":123,
+        "key23":["alpha","beta","gamma"],
+        "key24":{
+          "key241":234.123,
+          "key242":"value242"
+        }
+      }
+    },
+    /key2/key22/key22
+  )
+
+```
+
+####`(__ \ 'key2 \ 'key22).json.prune` 
+
+- Is a `Reads[JsObject]` that works only with JsObject
+
+####`(__ \ 'key2 \ 'key22).json.prune`
+
+- Removes given JsPath from input JSON (`key22` has disappeared under `key2`)
+
+Please note the resulting `JsObject` hasn't same keys order as input `JsObject`. This is due to the implementation of `JsObject` and to the merge mechanism. But this is not important since we have overridden `JsObject.equals` method to take this into account.
+
+> **Reminder:**
+> `jsPath.json.prune` only works with JsObject and removes given JsPath form input JSON)  
+> 
+> Please note that:
+> - `prune` doesn't work for recursive JsPath for the time being
+> - if `prune` doesn't find any branch to delete, it doesn't generate any error and returns unchanged JSON.
+
+# More complicated cases
+
+## Case 7: Pick a branch and update its content in 2 places
+
+```scala
+import play.api.libs.json._
+import play.api.libs.json.Reads._
+
+val jsonTransformer = (__ \ 'key2).json.pickBranch(
+  (__ \ 'key21).json.update( 
+    of[JsNumber].map{ case JsNumber(nb) => JsNumber(nb + 10) }
+  ) andThen 
+  (__ \ 'key23).json.update( 
+    of[JsArray].map{ case JsArray(arr) => JsArray(arr :+ JsString("delta")) }
+  )
+)
+
+scala> json.transform(jsonTransformer)
+res16: play.api.libs.json.JsResult[play.api.libs.json.JsObject] = 
+  JsSuccess(
+    {
+      "key2":{
+        "key21":133,
+        "key22":true,
+        "key23":["alpha","beta","gamma","delta"],
+        "key24":{
+          "key241":234.123,
+          "key242":"value242"
+        }
+      }
+    },
+    /key2
+  )
+
+```
+
+#### `(__ \ 'key2).json.pickBranch(reads: Reads[A <: JsValue])`
+
+- Extracts branch `__ \ 'key2` from input JSON and applies `reads` to the relative leaf of this branch (only to the content).
+
+#### `(__ \ 'key21).json.update(reads: Reads[A <: JsValue])` 
+
+- Updates `(__ \ 'key21)` branch.
+
+#### `of[JsNumber]` 
+
+- Is just a `Reads[JsNumber]`. 
+- Extracts a JsNumber from `(__ \ 'key21)`.
+
+#### `of[JsNumber].map{ case JsNumber(nb) => JsNumber(nb + 10) }` 
+
+- Reads a JsNumber (_value 123_ in `__ \ 'key21`).
+- Uses `Reads[A].map` to increase it by _10_ (in immutable way naturally).
+
+#### `andThen`
+
+- Is just the composition of 2 `Reads[A]`.
+- First reads is applied and then result is piped to second reads.
+
+#### `of[JsArray].map{ case JsArray(arr) => JsArray(arr :+ JsString("delta")` 
+
+- Reads a JsArray (_value [alpha, beta, gamma] in `__ \ 'key23`_).
+- Uses `Reads[A].map` to append `JsString("delta")` to it.
+
+> Please note the result is just the `__ \ 'key2` branch since we picked only this branch
+
+## Case 8: Pick a branch and prune a sub-branch
+
+```scala
+import play.api.libs.json._
+
+val jsonTransformer = (__ \ 'key2).json.pickBranch(
+  (__ \ 'key23).json.prune
+)
+
+scala> json.transform(jsonTransformer)
+res18: play.api.libs.json.JsResult[play.api.libs.json.JsObject] = 
+  JsSuccess(
+    {
+      "key2":{
+        "key21":123,
+        "key22":true,
+        "key24":{
+          "key241":234.123,
+          "key242":"value242"
+        }
+      }
+    },
+    /key2/key23
+  )
+
+```
+
+####`(__ \ 'key2).json.pickBranch(reads: Reads[A <: JsValue])`
+
+- Extracts branch `__ \ 'key2` from input JSON and applies `reads` to the relative leaf of this branch (only to the content).
+
+
+####`(__ \ 'key23).json.prune`
+
+- Removes branch `__ \ 'key23` from relative JSON
+
+> Please remark the result is just the `__ \ 'key2` branch without `key23` field.
+
+## What about combinators?
+
+I stop there before it becomes boring (if not yet)…
+
+Just keep in mind that you have now a huge toolkit to create generic JSON transformers. You can compose, map, flatmap transformers together into other transformers. So possibilities are almost infinite.
+
+But there is a final point to treat: mixing those great new JSON transformers with previously presented Reads combinators. This is quite trivial as JSON transformers are just `Reads[A <: JsValue]`
+
+Let's demonstrate by writing a __Gizmo to Gremlin__ JSON transformer.
+
+Here is Gizmo:
+
+```scala
+val gizmo = Json.obj(
+  "name" -> "gizmo",
+  "description" -> Json.obj(
+    "features" -> Json.arr( "hairy", "cute", "gentle"),
+    "size" -> 10,
+    "sex" -> "undefined",
+    "life_expectancy" -> "very old",
+    "danger" -> Json.obj(
+      "wet" -> "multiplies",
+      "feed after midnight" -> "becomes gremlin"
+    )
+  ),
+  "loves" -> "all"
+)
+```
+
+Here is Gremlin:
+
+```scala
+val gremlin = Json.obj(
+  "name" -> "gremlin",
+  "description" -> Json.obj(
+    "features" -> Json.arr("skinny", "ugly", "evil"),
+    "size" -> 30,
+    "sex" -> "undefined",
+    "life_expectancy" -> "very old",
+    "danger" -> "always"
+  ),
+  "hates" -> "all"
+)
+```
+
+Ok let's write a JSON transformer to do this transformation
+
+```scala
+import play.api.libs.json._
+import play.api.libs.json.Reads._
+import play.api.libs.functional.syntax._
+
+val gizmo2gremlin = (
+  (__ \ 'name).json.put(JsString("gremlin")) and
+  (__ \ 'description).json.pickBranch(
+    (__ \ 'size).json.update( of[JsNumber].map{ case JsNumber(size) => JsNumber(size * 3) } ) and
+    (__ \ 'features).json.put( Json.arr("skinny", "ugly", "evil") ) and
+    (__ \ 'danger).json.put(JsString("always"))
+    reduce
+  ) and
+  (__ \ 'hates).json.copyFrom( (__ \ 'loves).json.pick )
+) reduce
+
+scala> gizmo.transform(gizmo2gremlin)
+res22: play.api.libs.json.JsResult[play.api.libs.json.JsObject] = 
+  JsSuccess(
+    {
+      "name":"gremlin",
+      "description":{
+        "features":["skinny","ugly","evil"],
+        "size":30,
+        "sex":"undefined",
+        "life_expectancy":
+        "very old","danger":"always"
+      },
+      "hates":"all"
+    },
+  )
+```
+
+Here we are ;)  
+I'm not going to explain all of this because you should be able to understand now.  
+Just remark:
+
+####`(__ \ 'features).json.put(…)` is after `(__ \ 'size).json.update` so that it overwrites original `(__ \ 'features)`
+
+####`(Reads[JsObject] and Reads[JsObject]) reduce` 
+
+- It merges results of both `Reads[JsObject]` (JsObject ++ JsObject)
+- It also applies the same JSON to both `Reads[JsObject]` unlike `andThen` which injects the result of the first reads into second one.

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package scalaguide.json
+
+import play.api.libs.json.Json
+import org.specs2.mutable.Specification
+import play.api.libs.json.JsonNaming.SnakeCase
+
+class ScalaJsonAutomatedSpec extends Specification {
+
+  //#model
+  case class Resident(name: String, age: Int, role: Option[String])
+  //#model
+
+  //#model2
+  case class PlayUser(name: String, firstName: String, userAge: Int)
+  //#model2
+
+  val sampleJson = Json.parse(
+    """{
+      "name" : "Fiver",
+      "age" : 4
+    }"""
+  )
+  val sampleData = Resident("Fiver", 4, None)
+
+  val sampleJson2 = Json.parse(
+    """{
+      "name": "Schmitt",
+      "first_name": "Christian",
+      "user_age": 26
+    }"""
+  )
+  val sampleJson3 = Json.parse(
+    """{
+      "lightbend_name": "Schmitt",
+      "lightbend_firstName": "Christian",
+      "lightbend_userAge": 26
+    }"""
+  )
+  val sampleData2 = PlayUser("Schmitt", "Christian", 26)
+
+  "Scala JSON automated" should {
+    "produce a working Reads" in {
+
+      //#auto-reads
+      import play.api.libs.json._
+
+      implicit val residentReads = Json.reads[Resident]
+      //#auto-reads
+
+      sampleJson.as[Resident] must_=== sampleData
+    }
+    "do the same thing as a manual Reads" in {
+
+      //#manual-reads
+      import play.api.libs.json._
+      import play.api.libs.functional.syntax._
+
+      implicit val residentReads = (
+        (__ \ "name").read[String] and
+        (__ \ "age").read[Int] and
+        (__ \ "role").readNullable[String]
+      )(Resident)
+      //#manual-reads
+
+      sampleJson.as[Resident] must_=== sampleData
+    }
+    "produce a working Writes" in {
+
+      //#auto-writes
+      import play.api.libs.json._
+
+      implicit val residentWrites = Json.writes[Resident]
+      //#auto-writes
+
+      Json.toJson(sampleData) must_=== sampleJson
+    }
+    "produce a working Format" in {
+
+      //#auto-format
+      import play.api.libs.json._
+
+      implicit val residentFormat = Json.format[Resident]
+      //#auto-format
+
+      sampleJson.as[Resident] must_=== sampleData and {
+        Json.toJson(sampleData) must_=== sampleJson
+      }
+    }
+
+    "produce a working Writes with SnakeCase" in {
+      //#auto-naming-writes
+      import play.api.libs.json._
+
+      implicit val config = JsonConfiguration(SnakeCase)
+
+      implicit val userWrites: OWrites[PlayUser] = Json.writes[PlayUser]
+      //#auto-naming-writes
+
+      Json.toJson(sampleData2) must_=== sampleJson2
+    }
+
+    "produce a working Format with SnakeCase" in {
+      //#auto-naming-format
+      import play.api.libs.json._
+
+      implicit val config = JsonConfiguration(SnakeCase)
+
+      implicit val userFormat: OFormat[PlayUser] = Json.format[PlayUser]
+      //#auto-naming-format
+
+      sampleJson2.as[PlayUser] must_=== sampleData2 and {
+        Json.toJson(sampleData2) must_=== sampleJson2
+      }
+    }
+
+    "produce a working Reads with SnakeCase" in {
+      //#auto-naming-reads
+      import play.api.libs.json._
+
+      implicit val config = JsonConfiguration(SnakeCase)
+
+      implicit val userReads: Reads[PlayUser] = Json.reads[PlayUser]
+      //#auto-naming-reads
+
+      sampleJson2.as[PlayUser] must_=== sampleData2
+    }
+
+    "produce a working Format with Custom Naming" in {
+      //#auto-custom-naming-format
+      import play.api.libs.json._
+
+      object Lightbend extends JsonNaming {
+        override def apply(property: String): String = s"lightbend_$property"
+      }
+
+      implicit val config = JsonConfiguration(Lightbend)
+
+      implicit val customWrites: OFormat[PlayUser] = Json.format[PlayUser]
+      //#auto-custom-naming-format
+
+      sampleJson3.as[PlayUser] must_=== sampleData2 and {
+        Json.toJson(sampleData2) must_=== sampleJson3
+      }
+    }
+
+    "automatically serialize a case class to JSON" in {
+      //#auto-case-class-to-JSON
+      import play.api.libs.json._
+
+      implicit val residentWrites = Json.writes[Resident]
+
+      val resident = Resident(name = "Fiver", age = 4, role = None)
+
+      val residentJson: JsValue = Json.toJson(resident)
+      //#auto-case-class-to-JSON
+
+      residentJson must_=== sampleJson
+    }
+
+    "automatically convert JSON to a case class" in {
+      //#auto-JSON-to-case-class
+      import play.api.libs.json._
+
+      implicit val residentReads = Json.reads[Resident]
+
+      // In a request, a JsValue is likely to come from `request.body.asJson`
+      // or just `request.body` if using the `Action(parse.json)` body parser
+      val jsonString: JsValue = Json.parse(
+        """{
+          "name" : "Fiver",
+          "age" : 4
+        }"""
+      )
+
+      val residentFromJson: JsResult[Resident] = Json.fromJson[Resident](jsonString)
+
+      residentFromJson match {
+        case JsSuccess(r: Resident, path: JsPath) => println("Name: " + r.name)
+        case e: JsError => println("Errors: " + JsError.toJson(e).toString())
+      }
+      //#auto-JSON-to-case-class
+
+      residentFromJson.get must_=== sampleData
+    }
+  }
+}

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonCombinatorsSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonCombinatorsSpec.scala
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package scalaguide.json
+
+import org.specs2.mutable.Specification
+
+class ScalaJsonCombinatorsSpec extends Specification {
+
+  val sampleJson = {
+    //#sample-json
+    import play.api.libs.json._
+
+    val json: JsValue = Json.parse("""
+      {
+        "name" : "Watership Down",
+        "location" : {
+          "lat" : 51.235685,
+          "long" : -1.309197
+        },
+        "residents" : [ {
+          "name" : "Fiver",
+          "age" : 4,
+          "role" : null
+        }, {
+          "name" : "Bigwig",
+          "age" : 6,
+          "role" : "Owsla"
+        } ]
+      }
+      """)
+    //#sample-json
+    json
+  }
+
+  object SampleModel {
+    //#sample-model
+    case class Location(lat: Double, long: Double)
+    case class Resident(name: String, age: Int, role: Option[String])
+    case class Place(name: String, location: Location, residents: Seq[Resident])
+    //#sample-model
+  }
+
+  "Scala JSON" should {
+
+    "allow using JsPath" in {
+
+      //#jspath-define
+      import play.api.libs.json._
+
+      //###replace: val json = { ... }
+      val json: JsValue = sampleJson
+
+      // Simple path
+      val latPath = JsPath \ "location" \ "lat"
+
+      // Recursive path
+      val namesPath = JsPath \\ "name"
+
+      // Indexed path
+      val firstResidentPath = (JsPath \ "residents")(0)
+      //#jspath-define
+
+      //#jspath-define-alias
+      val longPath = __ \ "location" \ "long"
+      //#jspath-define-alias
+
+      //#jspath-traverse
+      val lat: List[JsValue] = latPath(json)
+      // List(JsNumber(51.235685))
+      //#jspath-traverse
+
+      //val name = (JsPath \ "name").read[String] and (JsPath \ "location").read[Int]
+      latPath.toString === "/location/lat"
+      namesPath.toString === "//name"
+      firstResidentPath.toString === "/residents(0)"
+    }
+
+    "allow creating simple Reads" in {
+
+      //#reads-imports
+      import play.api.libs.json._ // JSON library
+      import play.api.libs.json.Reads._ // Custom validation helpers
+      import play.api.libs.functional.syntax._ // Combinator syntax
+      //#reads-imports
+
+      //###replace: val json = { ... }
+      val json: JsValue = sampleJson
+
+      //#reads-simple
+      val nameReads: Reads[String] = (JsPath \ "name").read[String]
+      //#reads-simple
+
+      json.validate(nameReads) must beLike { case x: JsSuccess[String] => x.get === "Watership Down" }
+    }
+
+    "allow creating complex Reads" in {
+      import SampleModel._
+
+      import play.api.libs.json._
+      import play.api.libs.functional.syntax._
+
+      //###replace: val json = { ... }
+      val json: JsValue = sampleJson
+
+      //#reads-complex-builder
+      val locationReadsBuilder =
+        (JsPath \ "lat").read[Double] and
+          (JsPath \ "long").read[Double]
+      //#reads-complex-builder
+
+      //#reads-complex-buildertoreads
+      implicit val locationReads = locationReadsBuilder.apply(Location.apply _)
+      //#reads-complex-buildertoreads
+
+      val locationResult = (json \ "location").validate[Location]
+      locationResult must beLike { case x: JsSuccess[Location] => x.get.lat === 51.235685 }
+    }
+
+    "allow creating complex Reads in a single statement" in {
+      import SampleModel._
+
+      import play.api.libs.json._
+      import play.api.libs.functional.syntax._
+
+      //###replace: val json = { ... }
+      val json: JsValue = sampleJson
+
+      //#reads-complex-statement
+      implicit val locationReads: Reads[Location] = (
+        (JsPath \ "lat").read[Double] and
+        (JsPath \ "long").read[Double]
+      )(Location.apply _)
+      //#reads-complex-statement
+
+      val locationResult = (json \ "location").validate[Location]
+      locationResult must beLike { case x: JsSuccess[Location] => x.get.lat === 51.235685 }
+    }
+
+    "allow validation with Reads" in {
+      import SampleModel._
+
+      import play.api.libs.json._
+      import play.api.libs.json.Reads._
+      import play.api.libs.functional.syntax._
+
+      //#reads-validation-simple
+      //###replace: val json = { ... }
+      val json: JsValue = sampleJson
+
+      val nameReads: Reads[String] = (JsPath \ "name").read[String]
+
+      val nameResult: JsResult[String] = json.validate[String](nameReads)
+
+      nameResult match {
+        case s: JsSuccess[String] => println("Name: " + s.get)
+        case e: JsError => println("Errors: " + JsError.toJson(e).toString())
+      }
+      //#reads-validation-simple
+      nameResult must beLike { case x: JsSuccess[String] => x.get === "Watership Down" }
+
+      //#reads-validation-custom
+      val improvedNameReads =
+        (JsPath \ "name").read[String](minLength[String](2))
+      //#reads-validation-custom
+      json.validate[String](improvedNameReads) must beLike { case x: JsSuccess[String] => x.get === "Watership Down" }
+
+    }
+
+    "allow creating Reads for model" in {
+      import SampleModel._
+
+      //#reads-model
+      import play.api.libs.json._
+      import play.api.libs.json.Reads._
+      import play.api.libs.functional.syntax._
+
+      implicit val locationReads: Reads[Location] = (
+        (JsPath \ "lat").read[Double](min(-90.0) keepAnd max(90.0)) and
+        (JsPath \ "long").read[Double](min(-180.0) keepAnd max(180.0))
+      )(Location.apply _)
+
+      implicit val residentReads: Reads[Resident] = (
+        (JsPath \ "name").read[String](minLength[String](2)) and
+        (JsPath \ "age").read[Int](min(0) keepAnd max(150)) and
+        (JsPath \ "role").readNullable[String]
+      )(Resident.apply _)
+
+      implicit val placeReads: Reads[Place] = (
+        (JsPath \ "name").read[String](minLength[String](2)) and
+        (JsPath \ "location").read[Location] and
+        (JsPath \ "residents").read[Seq[Resident]]
+      )(Place.apply _)
+
+      //###replace: val json = { ... }
+      val json: JsValue = sampleJson
+
+      json.validate[Place] match {
+        case s: JsSuccess[Place] => {
+          val place: Place = s.get
+          // do something with place
+        }
+        case e: JsError => {
+          // error handling flow
+        }
+      }
+      //#reads-model
+
+      json.validate[Place] must beLike { case x: JsSuccess[Place] => x.get.name === "Watership Down" }
+    }
+
+    "allow creating Writes for model" in {
+      import SampleModel._
+
+      //#writes-model
+      import play.api.libs.json._
+      import play.api.libs.functional.syntax._
+
+      implicit val locationWrites: Writes[Location] = (
+        (JsPath \ "lat").write[Double] and
+        (JsPath \ "long").write[Double]
+      )(unlift(Location.unapply))
+
+      implicit val residentWrites: Writes[Resident] = (
+        (JsPath \ "name").write[String] and
+        (JsPath \ "age").write[Int] and
+        (JsPath \ "role").writeNullable[String]
+      )(unlift(Resident.unapply))
+
+      implicit val placeWrites: Writes[Place] = (
+        (JsPath \ "name").write[String] and
+        (JsPath \ "location").write[Location] and
+        (JsPath \ "residents").write[Seq[Resident]]
+      )(unlift(Place.unapply))
+
+      val place = Place(
+        "Watership Down",
+        Location(51.235685, -1.309197),
+        Seq(
+          Resident("Fiver", 4, None),
+          Resident("Bigwig", 6, Some("Owsla"))
+        )
+      )
+
+      val json = Json.toJson(place)
+      //#writes-model
+
+      val some = (JsPath \ "lat").write[Double] and (JsPath \ "long").write[Double]
+      val placeSome = Place.unapply(place)
+
+      (json \ "name").get === JsString("Watership Down")
+    }
+
+    "allow creating Reads/Writes for recursive types" in {
+
+      import play.api.libs.json._
+      import play.api.libs.json.Reads._
+      import play.api.libs.functional.syntax._
+
+      //#reads-writes-recursive
+      case class User(name: String, friends: Seq[User])
+
+      implicit lazy val userReads: Reads[User] = (
+        (__ \ "name").read[String] and
+        (__ \ "friends").lazyRead(Reads.seq[User](userReads))
+      )(User)
+
+      implicit lazy val userWrites: Writes[User] = (
+        (__ \ "name").write[String] and
+        (__ \ "friends").lazyWrite(Writes.seq[User](userWrites))
+      )(unlift(User.unapply))
+      //#reads-writes-recursive
+
+      // Use Reads for JSON -> model
+      val json: JsValue = Json.parse("""
+      {
+        "name" : "Fiver",
+        "friends" : [ {
+          "name" : "Bigwig",
+          "friends" : []
+        }, {
+          "name" : "Hazel",
+          "friends" : []
+        } ]
+      }
+      """)
+      val userResult = json.validate[User]
+      userResult must beLike { case x: JsSuccess[User] => x.get.name === "Fiver" }
+
+      // Use Writes for model -> JSON
+      val jsonFromUser = Json.toJson(userResult.get)
+      (jsonFromUser \ "name").as[String] === "Fiver"
+    }
+
+    "allow creating Format from components" in {
+      import SampleModel._
+
+      import play.api.libs.json._
+      import play.api.libs.json.Reads._
+      import play.api.libs.functional.syntax._
+
+      //#format-components
+      val locationReads: Reads[Location] = (
+        (JsPath \ "lat").read[Double](min(-90.0) keepAnd max(90.0)) and
+        (JsPath \ "long").read[Double](min(-180.0) keepAnd max(180.0))
+      )(Location.apply _)
+
+      val locationWrites: Writes[Location] = (
+        (JsPath \ "lat").write[Double] and
+        (JsPath \ "long").write[Double]
+      )(unlift(Location.unapply))
+
+      implicit val locationFormat: Format[Location] =
+        Format(locationReads, locationWrites)
+      //#format-components
+
+      // Use Reads for JSON -> model
+      val json: JsValue = Json.parse("""
+      {
+        "lat" : 51.235685,
+        "long" : -1.309197
+      }
+      """)
+      val location = json.validate[Location].get
+      location === Location(51.235685, -1.309197)
+
+      // Use Writes for model -> JSON
+      val jsonFromLocation = Json.toJson(location)
+      (jsonFromLocation \ "lat").as[Double] === 51.235685
+    }
+
+    "allow creating Format from combinators" in {
+      import SampleModel._
+
+      import play.api.libs.json._
+      import play.api.libs.json.Reads._
+      import play.api.libs.functional.syntax._
+
+      //#format-combinators
+      implicit val locationFormat: Format[Location] = (
+        (JsPath \ "lat").format[Double](min(-90.0) keepAnd max(90.0)) and
+        (JsPath \ "long").format[Double](min(-180.0) keepAnd max(180.0))
+      )(Location.apply, unlift(Location.unapply))
+      //#format-combinators
+
+      // Use Reads for JSON -> model
+      val json: JsValue = Json.parse("""
+      {
+        "lat" : 51.235685,
+        "long" : -1.309197
+      }
+      """)
+      val location = json.validate[Location].get
+      location === Location(51.235685, -1.309197)
+
+      // Use Writes for model -> JSON
+      val jsonFromLocation = Json.toJson(location)
+      (jsonFromLocation \ "lat").as[Double] === 51.235685
+    }
+
+  }
+
+}

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package scalaguide.json
+
+import org.specs2.mutable.Specification
+
+class ScalaJsonSpec extends Specification {
+
+  val sampleJson = {
+    //#convert-from-string
+    import play.api.libs.json._
+
+    val json: JsValue = Json.parse("""
+      {
+        "name" : "Watership Down",
+        "location" : {
+          "lat" : 51.235685,
+          "long" : -1.309197
+        },
+        "residents" : [ {
+          "name" : "Fiver",
+          "age" : 4,
+          "role" : null
+        }, {
+          "name" : "Bigwig",
+          "age" : 6,
+          "role" : "Owsla"
+        } ]
+      }
+      """)
+    //#convert-from-string
+    json
+  }
+
+  object SampleModel {
+    //#sample-model
+    case class Location(lat: Double, long: Double)
+    case class Resident(name: String, age: Int, role: Option[String])
+    case class Place(name: String, location: Location, residents: Seq[Resident])
+    //#sample-model
+  }
+
+  "Scala JSON" should {
+    "parse json" in {
+      import play.api.libs.json._
+      val json = sampleJson
+      (json \ "name").get must_== JsString("Watership Down")
+      (json \ "location" \ "lat").get must_== JsNumber(51.235685)
+    }
+
+    "allow constructing json using case classes" in {
+      //#convert-from-classes
+      import play.api.libs.json._
+
+      val json: JsValue = JsObject(Seq(
+        "name" -> JsString("Watership Down"),
+        "location" -> JsObject(Seq("lat" -> JsNumber(51.235685), "long" -> JsNumber(-1.309197))),
+        "residents" -> JsArray(Seq(
+          JsObject(Seq(
+            "name" -> JsString("Fiver"),
+            "age" -> JsNumber(4),
+            "role" -> JsNull
+          )),
+          JsObject(Seq(
+            "name" -> JsString("Bigwig"),
+            "age" -> JsNumber(6),
+            "role" -> JsString("Owsla")
+          ))
+        ))
+      ))
+      //#convert-from-classes
+      (json \ "name").get must_== JsString("Watership Down")
+    }
+
+    "allow constructing json using factory methods" in {
+      //#convert-from-factory
+      import play.api.libs.json.{ JsNull, Json, JsString, JsValue }
+
+      val json: JsValue = Json.obj(
+        "name" -> "Watership Down",
+        "location" -> Json.obj("lat" -> 51.235685, "long" -> -1.309197),
+        "residents" -> Json.arr(
+          Json.obj(
+            "name" -> "Fiver",
+            "age" -> 4,
+            "role" -> JsNull
+          ),
+          Json.obj(
+            "name" -> "Bigwig",
+            "age" -> 6,
+            "role" -> "Owsla"
+          )
+        )
+      )
+      //#convert-from-factory
+      (json \ "name").get must_== JsString("Watership Down")
+    }
+
+    "allow converting simple types" in {
+      //#convert-from-simple
+      import play.api.libs.json._
+
+      // basic types
+      val jsonString = Json.toJson("Fiver")
+      val jsonNumber = Json.toJson(4)
+      val jsonBoolean = Json.toJson(false)
+
+      // collections of basic types
+      val jsonArrayOfInts = Json.toJson(Seq(1, 2, 3, 4))
+      val jsonArrayOfStrings = Json.toJson(List("Fiver", "Bigwig"))
+
+      //#convert-from-simple
+
+      jsonString === JsString("Fiver")
+      jsonNumber === JsNumber(4)
+      jsonBoolean === JsBoolean(false)
+      jsonArrayOfInts === Json.arr(1, 2, 3, 4)
+      jsonArrayOfStrings === Json.arr("Fiver", "Bigwig")
+    }
+
+    "allow converting of models" in {
+
+      import SampleModel._
+
+      //#convert-from-model
+      import play.api.libs.json._
+
+      implicit val locationWrites = new Writes[Location] {
+        def writes(location: Location) = Json.obj(
+          "lat" -> location.lat,
+          "long" -> location.long
+        )
+      }
+
+      implicit val residentWrites = new Writes[Resident] {
+        def writes(resident: Resident) = Json.obj(
+          "name" -> resident.name,
+          "age" -> resident.age,
+          "role" -> resident.role
+        )
+      }
+
+      implicit val placeWrites = new Writes[Place] {
+        def writes(place: Place) = Json.obj(
+          "name" -> place.name,
+          "location" -> place.location,
+          "residents" -> place.residents
+        )
+      }
+
+      val place = Place(
+        "Watership Down",
+        Location(51.235685, -1.309197),
+        Seq(
+          Resident("Fiver", 4, None),
+          Resident("Bigwig", 6, Some("Owsla"))
+        )
+      )
+
+      val json = Json.toJson(place)
+      //#convert-from-model
+
+      (json \ "name").get === JsString("Watership Down")
+    }
+
+    "allow converting models preferred" in {
+
+      import SampleModel._
+
+      //#convert-from-model-prefwrites
+      import play.api.libs.json._
+      import play.api.libs.functional.syntax._
+
+      implicit val locationWrites: Writes[Location] = (
+        (JsPath \ "lat").write[Double] and
+        (JsPath \ "long").write[Double]
+      )(unlift(Location.unapply))
+
+      implicit val residentWrites: Writes[Resident] = (
+        (JsPath \ "name").write[String] and
+        (JsPath \ "age").write[Int] and
+        (JsPath \ "role").writeNullable[String]
+      )(unlift(Resident.unapply))
+
+      implicit val placeWrites: Writes[Place] = (
+        (JsPath \ "name").write[String] and
+        (JsPath \ "location").write[Location] and
+        (JsPath \ "residents").write[Seq[Resident]]
+      )(unlift(Place.unapply))
+      //#convert-from-model-prefwrites
+
+      val place = Place(
+        "Watership Down",
+        Location(51.235685, -1.309197),
+        Seq(
+          Resident("Fiver", 4, None),
+          Resident("Bigwig", 6, Some("Owsla"))
+        )
+      )
+
+      val json = Json.toJson(place)
+      //#convert-from-model
+
+      (json \ "name").get === JsString("Watership Down")
+    }
+
+    "allow traversing JsValue tree" in {
+
+      import play.api.libs.json._
+      val json = sampleJson
+
+      //#traverse-simple-path
+      val lat = (json \ "location" \ "lat").get
+      // returns JsNumber(51.235685)
+      //#traverse-simple-path
+
+      lat === JsNumber(51.235685)
+
+      //#traverse-recursive-path
+      val names = json \\ "name"
+      // returns Seq(JsString("Watership Down"), JsString("Fiver"), JsString("Bigwig"))
+      //#traverse-recursive-path
+      names === Seq(JsString("Watership Down"), JsString("Fiver"), JsString("Bigwig"))
+
+      //#traverse-array-index
+      val bigwig = (json \ "residents")(1)
+      // returns {"name":"Bigwig","age":6,"role":"Owsla"}
+      //#traverse-array-index
+      (bigwig \ "name").get === JsString("Bigwig")
+    }
+
+    "allow converting JsValue to String" in {
+
+      import play.api.libs.json._
+      val json = sampleJson
+
+      //#convert-to-string
+      val minifiedString: String = Json.stringify(json)
+      //#convert-to-string
+
+      //#convert-to-string-pretty
+      val readableString: String = Json.prettyPrint(json)
+      //#convert-to-string-pretty
+
+      minifiedString must contain("Fiver")
+      readableString must contain("Bigwig")
+    }
+
+    "allow converting JsValue using as" in {
+
+      import play.api.libs.json._
+      val json = sampleJson
+
+      //#convert-to-type-as
+      val name = (json \ "name").as[String]
+      // "Watership Down"
+
+      val names = (json \\ "name").map(_.as[String])
+      // Seq("Watership Down", "Fiver", "Bigwig")
+      //#convert-to-type-as
+
+      name === "Watership Down"
+      names === Seq("Watership Down", "Fiver", "Bigwig")
+    }
+
+    "allow converting JsValue using asOpt" in {
+
+      import play.api.libs.json._
+      val json = sampleJson
+
+      //#convert-to-type-as-opt
+      val nameOption = (json \ "name").asOpt[String]
+      // Some("Watership Down")
+
+      val bogusOption = (json \ "bogus").asOpt[String]
+      // None
+      //#convert-to-type-as-opt
+
+      nameOption === Some("Watership Down")
+      bogusOption must beNone
+    }
+
+    "allow converting JsValue using validate" in {
+      import SampleModel._
+
+      import play.api.libs.json._
+      import play.api.libs.json.Reads._
+
+      //#convert-to-type-validate
+      //###replace: val json = { ... }
+      val json: JsValue = sampleJson
+
+      val nameResult: JsResult[String] = (json \ "name").validate[String]
+
+      // Pattern matching
+      nameResult match {
+        case s: JsSuccess[String] => println("Name: " + s.get)
+        case e: JsError => println("Errors: " + JsError.toJson(e).toString())
+      }
+
+      // Fallback value
+      val nameOrFallback = nameResult.getOrElse("Undefined")
+
+      // map
+      val nameUpperResult: JsResult[String] = nameResult.map(_.toUpperCase())
+
+      // fold
+      val nameOption: Option[String] = nameResult.fold(
+        invalid = {
+        fieldErrors =>
+          fieldErrors.foreach(x => {
+            println("field: " + x._1 + ", errors: " + x._2)
+          })
+          None
+      },
+        valid = {
+        name => Some(name)
+      }
+      )
+      //#convert-to-type-validate
+      nameResult must beLike { case x: JsSuccess[String] => x.get === "Watership Down" }
+    }
+
+    "allow converting JsValue to model" in {
+
+      import SampleModel._
+
+      //#convert-to-model
+      import play.api.libs.json._
+      import play.api.libs.functional.syntax._
+
+      implicit val locationReads: Reads[Location] = (
+        (JsPath \ "lat").read[Double] and
+        (JsPath \ "long").read[Double]
+      )(Location.apply _)
+
+      implicit val residentReads: Reads[Resident] = (
+        (JsPath \ "name").read[String] and
+        (JsPath \ "age").read[Int] and
+        (JsPath \ "role").readNullable[String]
+      )(Resident.apply _)
+
+      implicit val placeReads: Reads[Place] = (
+        (JsPath \ "name").read[String] and
+        (JsPath \ "location").read[Location] and
+        (JsPath \ "residents").read[Seq[Resident]]
+      )(Place.apply _)
+
+      //###replace: val json = { ... }
+      val json = sampleJson
+
+      val placeResult: JsResult[Place] = json.validate[Place]
+      // JsSuccess(Place(...),)
+
+      val residentResult: JsResult[Resident] = (json \ "residents")(1).validate[Resident]
+      // JsSuccess(Resident(Bigwig,6,Some(Owsla)),)
+      //#convert-to-model
+
+      placeResult must beLike { case x: JsSuccess[Place] => x.get.name === "Watership Down" }
+      residentResult must beLike { case x: JsSuccess[Resident] => x.get.name === "Bigwig" }
+    }
+
+  }
+
+}

--- a/docs/manual/working/scalaGuide/main/json/index.toc
+++ b/docs/manual/working/scalaGuide/main/json/index.toc
@@ -1,0 +1,5 @@
+ScalaJson:JSON basics
+ScalaJsonHttp:JSON with HTTP
+ScalaJsonCombinators:JSON Reads/Writes/Format Combinators
+ScalaJsonAutomated:JSON automated mapping
+ScalaJsonTransformers:JSON Transformers

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -1,0 +1,5 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.6.0-SNAPSHOT"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,11 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.3.4"))
-//addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.5.10"))
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.13")
 


### PR DESCRIPTION
This PR moves most of the Play JSON docs out of the Play Framework core project and into the Play JSON project. Having more documentation within the Play JSON repo should make it easier to keep the Play JSON docs in sync with the code.

The documentation tests are run automatically at the same time as the core Play JSON tests, so the code in the documentation should stay fresh.

The docs are tested and published as part of the main Play JSON sbt build process. The docs will be published as a `playdoc` artifact and aggregated together with [Omnidoc](https://github.com/playframework/omnidoc).

The docs have been mostly integrated into the main Play JSON sbt build, but there is also a *separate* sbt build configuration inside the `docs` directory. This is separate from the main build in order to avoid a circular dependency between Play JSON and Play's `play-docs-sbt-plugin`. There is some information about this in the `docs/README.md` file.

The documentation has been taken as-is from Play revision 9436dd2, with only a few small typo fixes. This PR is just attempting to get the docs migrated into the Play JSON project. Improving the content of the docs is a job for another day!