### PR TITLE
Add missing type annotations in JsResult

### DIFF
--- a/play-json/shared/src/main/scala/JsResult.scala
+++ b/play-json/shared/src/main/scala/JsResult.scala
@@ -162,7 +162,7 @@ sealed trait JsResult[+A] { self =>
     case JsError(es) => JsError(es.map { case (p, s) => path ++ p -> s })
   }
 
-  /** Not recommanded */
+  /** Not recommended */
   def get: A
 
   def getOrElse[AA >: A](t: => AA): AA = this match {
@@ -175,12 +175,12 @@ sealed trait JsResult[+A] { self =>
     case JsError(_) => t
   }
 
-  def asOpt = this match {
+  def asOpt: Option[A] = this match {
     case JsSuccess(v, _) => Some(v)
     case JsError(_) => None
   }
 
-  def asEither = this match {
+  def asEither: Either[Seq[(JsPath, Seq[JsonValidationError])], A] = this match {
     case JsSuccess(v, _) => Right(v)
     case JsError(e) => Left(e)
   }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

Add missing type annotations on public methods

## Background Context

The unannotated methos generate `X with Product with Serializable` in some cases without annotation
