### PR TITLE
Codec for Duration

### DIFF
--- a/play-json/jvm/src/test/scala/play/api/libs/json/WritesSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/WritesSpec.scala
@@ -18,8 +18,7 @@ import java.time.format.DateTimeFormatter
 import org.specs2.specification.core.Fragment
 
 class WritesSpec extends org.specs2.mutable.Specification {
-
-  title("JSON Writes")
+  "JSON Writes" title
 
   "Local date/time" should {
     val DefaultWrites = implicitly[Writes[LocalDateTime]]

--- a/play-json/shared/src/main/scala/Reads.scala
+++ b/play-json/shared/src/main/scala/Reads.scala
@@ -447,7 +447,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
       (n.toDouble * 1000).toLong
     } else n.toLong
 
-    FiniteDuration(millis.toLong, "ms")
+    FiniteDuration(millis, "ms")
   }
 
   /**

--- a/play-json/shared/src/main/scala/Reads.scala
+++ b/play-json/shared/src/main/scala/Reads.scala
@@ -492,7 +492,6 @@ trait DefaultReads extends LowPriorityDefaultReads {
       JsSuccess(Duration.Inf)
 
     case JsString("MinusInf") | JsString("-Inf") => JsSuccess(Duration.MinusInf)
-    case JsString("0") => JsSuccess(Duration.Zero)
     case JsString("Undefined") => JsSuccess(Duration.Undefined)
     case JsString(finite) => try {
       JsSuccess(Duration(finite))

--- a/play-json/shared/src/main/scala/Reads.scala
+++ b/play-json/shared/src/main/scala/Reads.scala
@@ -470,7 +470,6 @@ trait DefaultReads extends LowPriorityDefaultReads {
    */
   implicit val finiteDurationReads: Reads[FiniteDuration] =
     Reads[FiniteDuration] {
-      case JsString("0") => JsSuccess(Duration.Zero)
       case JsString("Undefined") => JsError(s"error.invalid.finiteDuration")
       case JsString(input) => try {
         val d = Duration(input)

--- a/play-json/shared/src/main/scala/Reads.scala
+++ b/play-json/shared/src/main/scala/Reads.scala
@@ -458,6 +458,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
     }
 
   /**
+   * Number deserializer for Scala FiniteDuration:
    * If the number is decimal, considering it's /1000 of milliseconds,
    * otherwise considering it's directly in milliseconds.
    */

--- a/play-json/shared/src/main/scala/Writes.scala
+++ b/play-json/shared/src/main/scala/Writes.scala
@@ -99,6 +99,7 @@ object Writes extends PathWrites with ConstraintWrites with DefaultWrites {
         Writes[B](b => wa.writes(f(b)))
     }
 
+  /** Functional factory */
   def apply[A](f: A => JsValue): Writes[A] = new Writes[A] {
     def writes(a: A): JsValue = f(a)
   }
@@ -213,20 +214,20 @@ trait DefaultWrites extends LowPriorityWrites {
   /**
    * Serializer for Option.
    */
-  implicit def OptionWrites[T](implicit fmt: Writes[T]): Writes[Option[T]] = new Writes[Option[T]] {
-    def writes(o: Option[T]) = o match {
+  implicit def OptionWrites[T](implicit fmt: Writes[T]): Writes[Option[T]] =
+    Writes[Option[T]] {
       case Some(value) => fmt.writes(value)
-      case None => JsNull
+      case _ => JsNull
     }
-  }
 
   /**
    * Serializer for java.util.Date
    * @param pattern the pattern used by SimpleDateFormat
    */
-  def dateWrites(pattern: String): Writes[java.util.Date] = new Writes[java.util.Date] {
-    def writes(d: java.util.Date): JsValue = JsString(new java.text.SimpleDateFormat(pattern).format(d))
-  }
+  def dateWrites(pattern: String): Writes[java.util.Date] =
+    Writes[java.util.Date] { d =>
+      JsString(new java.text.SimpleDateFormat(pattern).format(d))
+    }
 
   /**
    * Default Serializer java.util.Date -> JsNumber(d.getTime (nb of ms))
@@ -239,9 +240,10 @@ trait DefaultWrites extends LowPriorityWrites {
    * Serializer for java.sql.Date
    * @param pattern the pattern used by SimpleDateFormat
    */
-  def sqlDateWrites(pattern: String): Writes[java.sql.Date] = new Writes[java.sql.Date] {
-    def writes(d: java.sql.Date): JsValue = JsString(new java.text.SimpleDateFormat(pattern).format(d))
-  }
+  def sqlDateWrites(pattern: String): Writes[java.sql.Date] =
+    Writes[java.sql.Date] { d =>
+      JsString(new java.text.SimpleDateFormat(pattern).format(d))
+    }
 
   /**
    * Serializer for Scala Duration

--- a/play-json/shared/src/main/scala/Writes.scala
+++ b/play-json/shared/src/main/scala/Writes.scala
@@ -5,7 +5,7 @@ package play.api.libs.json
 
 import play.api.libs.functional.ContravariantFunctor
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.annotation.implicitNotFound
 import scala.collection._
 import scala.reflect.ClassTag
@@ -256,6 +256,14 @@ trait DefaultWrites extends LowPriorityWrites {
 
     case finite => JsString(finite.toString)
   }
+
+  /**
+   * NumberSerializer for Scala FiniteDuration
+   */
+  val finiteDurationNumberWrites: Writes[FiniteDuration] =
+    Writes[FiniteDuration] { finite =>
+      JsNumber(BigDecimal(finite.toMillis))
+    }
 
   /**
    * Serializer for java.util.UUID

--- a/play-json/shared/src/main/scala/Writes.scala
+++ b/play-json/shared/src/main/scala/Writes.scala
@@ -249,7 +249,7 @@ trait DefaultWrites extends LowPriorityWrites {
   implicit val durationWrites: Writes[Duration] = Writes[Duration] {
     case Duration.Inf => JsString("Inf")
     case Duration.MinusInf => JsString("MinusInf")
-    case Duration.Zero => JsString("0")
+    case Duration.Zero => JsNumber(0)
 
     case undefined if (undefined eq Duration.Undefined) =>
       JsString("Undefined")

--- a/play-json/shared/src/main/scala/Writes.scala
+++ b/play-json/shared/src/main/scala/Writes.scala
@@ -5,6 +5,7 @@ package play.api.libs.json
 
 import play.api.libs.functional.ContravariantFunctor
 
+import scala.concurrent.duration.Duration
 import scala.annotation.implicitNotFound
 import scala.collection._
 import scala.reflect.ClassTag
@@ -240,6 +241,20 @@ trait DefaultWrites extends LowPriorityWrites {
    */
   def sqlDateWrites(pattern: String): Writes[java.sql.Date] = new Writes[java.sql.Date] {
     def writes(d: java.sql.Date): JsValue = JsString(new java.text.SimpleDateFormat(pattern).format(d))
+  }
+
+  /**
+   * Serializer for Scala Duration
+   */
+  implicit val durationWrites: Writes[Duration] = Writes[Duration] {
+    case Duration.Inf => JsString("Inf")
+    case Duration.MinusInf => JsString("MinusInf")
+    case Duration.Zero => JsString("0")
+
+    case undefined if (undefined eq Duration.Undefined) =>
+      JsString("Undefined")
+
+    case finite => JsString(finite.toString)
   }
 
   /**

--- a/play-json/shared/src/test/scala/ReadsSharedSpec.scala
+++ b/play-json/shared/src/test/scala/ReadsSharedSpec.scala
@@ -73,10 +73,9 @@ class ReadsSharedSpec extends WordSpec with MustMatchers {
         JsNumber(BigDecimal(0D)) -> JsSuccess(Duration.Zero),
         JsString("1 second") -> JsSuccess(FiniteDuration(1L, "second")),
         JsString("5 seconds") -> JsSuccess(Duration("5seconds")),
-        JsNumber(BigDecimal(1.23D)) -> JsSuccess(Duration("1230ms"))
+        JsNumber(BigDecimal(1.23D)) -> JsError("error.expected.duration")
       )) { (json, expected) =>
         Json.fromJson[Duration](json) mustEqual expected
-        Json.fromJson[FiniteDuration](json) mustEqual expected
       }
     }
 
@@ -88,7 +87,12 @@ class ReadsSharedSpec extends WordSpec with MustMatchers {
     }
 
     "fail for invalid input as FiniteDuration" in {
-      forAll(Table[JsValue]("json", JsString("foo"), JsNull)) { json =>
+      forAll(Table[JsValue](
+        "json",
+        JsString("foo"),
+        JsNull,
+        JsNumber(BigDecimal(1.23D))
+      )) { json =>
         Json.fromJson[FiniteDuration](json) mustEqual (
           JsError("error.expected.finiteDuration"))
       }
@@ -99,9 +103,9 @@ class ReadsSharedSpec extends WordSpec with MustMatchers {
 
       forAll(Table(
         "json" -> "expected",
-        JsString("0s") -> JsError("error.expected.finiteDuration")
+        JsString("0s") -> JsError("error.expected.finiteDuration"),
         JsNumber(BigDecimal(0D)) -> JsSuccess(Duration.Zero),
-        JsNumber(BigDecimal(1.23D)) -> JsSuccess(Duration("1230ms")),
+        JsNumber(BigDecimal(1.23D)) -> JsError("error.expected.finiteDuration"),
         JsNull -> JsError("error.expected.finiteDuration")
       )) { (json, expected) =>
         Json.fromJson[FiniteDuration](json) mustEqual expected

--- a/play-json/shared/src/test/scala/ReadsSharedSpec.scala
+++ b/play-json/shared/src/test/scala/ReadsSharedSpec.scala
@@ -5,7 +5,10 @@ package play.api.libs.json
 
 import java.util.Locale
 
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+
 import org.scalatest._
+import org.scalatest.prop.TableDrivenPropertyChecks._
 
 class ReadsSharedSpec extends WordSpec with MustMatchers {
   "Reads flatMap" should {
@@ -48,13 +51,13 @@ class ReadsSharedSpec extends WordSpec with MustMatchers {
   "Functionnal Reads" should {
     import play.api.libs.functional.syntax._
 
-    implicit val reads: Reads[Owner] = (
-      (__ \ "login").read[String] and
-      (__ \ "avatar").read[String] and
-      (__ \ "url").read[String]
-    )(Owner)
-
     "be successful for simple case class Owner" in {
+      implicit val reads: Reads[Owner] = (
+        (__ \ "login").read[String] and
+        (__ \ "avatar").read[String] and
+        (__ \ "url").read[String]
+      )(Owner)
+
       val jsObj = Json.obj(
         "login" -> "foo",
         "avatar" -> "url://avatar",
@@ -62,6 +65,38 @@ class ReadsSharedSpec extends WordSpec with MustMatchers {
       )
 
       Json.parse(Json.stringify(jsObj)) mustEqual jsObj
+    }
+
+    "be successful for FiniteDuration" in {
+      forAll(Table(
+        "json" -> "expected",
+        JsString("0") -> JsSuccess(Duration.Zero),
+        JsNumber(BigDecimal(0D)) -> JsSuccess(Duration.Zero),
+        JsString("1 second") -> JsSuccess(FiniteDuration(1L, "second")),
+        JsString("5 seconds") -> JsSuccess(Duration("5seconds")),
+        JsString("foo") -> JsError("error.invalid.duration"),
+        JsNumber(BigDecimal(1.23D)) -> JsSuccess(Duration("1230ms")),
+        JsNull -> JsError("error.expected.duration")
+      )) { (json, expected) =>
+        Json.fromJson[Duration](json) mustEqual expected
+        Json.fromJson[FiniteDuration](json) mustEqual (expected)
+      }
+    }
+
+    "be successful for infinite Duration" in forAll(Table(
+      "repr" -> "duration",
+      "Inf" -> Duration.Inf,
+      "PlusInf" -> Duration.Inf,
+      "+Inf" -> Duration.Inf,
+      "MinusInf" -> Duration.MinusInf,
+      "-Inf" -> Duration.MinusInf,
+      "Undefined" -> Duration.Undefined
+    )) { (repr, duration) =>
+      Json.fromJson[Duration](JsString(repr)) mustEqual JsSuccess(duration)
+
+      Json.fromJson[FiniteDuration](JsString(repr)) mustEqual (
+        JsError("error.invalid.finiteDuration")
+      )
     }
   }
 

--- a/play-json/shared/src/test/scala/ReadsSharedSpec.scala
+++ b/play-json/shared/src/test/scala/ReadsSharedSpec.scala
@@ -70,7 +70,6 @@ class ReadsSharedSpec extends WordSpec with MustMatchers {
     "be successful for FiniteDuration" in {
       forAll(Table(
         "json" -> "expected",
-        JsString("0") -> JsSuccess(Duration.Zero),
         JsNumber(BigDecimal(0D)) -> JsSuccess(Duration.Zero),
         JsString("1 second") -> JsSuccess(FiniteDuration(1L, "second")),
         JsString("5 seconds") -> JsSuccess(Duration("5seconds")),
@@ -100,7 +99,7 @@ class ReadsSharedSpec extends WordSpec with MustMatchers {
 
       forAll(Table(
         "json" -> "expected",
-        JsString("0") -> JsError("error.expected.finiteDuration"),
+        JsString("0s") -> JsError("error.expected.finiteDuration")
         JsNumber(BigDecimal(0D)) -> JsSuccess(Duration.Zero),
         JsNumber(BigDecimal(1.23D)) -> JsSuccess(Duration("1230ms")),
         JsNull -> JsError("error.expected.finiteDuration")

--- a/play-json/shared/src/test/scala/WritesSharedSpec.scala
+++ b/play-json/shared/src/test/scala/WritesSharedSpec.scala
@@ -27,18 +27,19 @@ class WritesSharedSpec extends WordSpec with MustMatchers {
 
     "be successful for finite Duration" in forAll(Table(
       "duration" -> "json",
-      Duration.Zero -> "0",
-      FiniteDuration(1L, "second") -> "1 second",
-      Duration("5seconds") -> "5 seconds")) { (duration, json) =>
-      Json.toJson(duration) mustEqual JsString(json)
+      Duration.Zero -> JsNumber(BigDecimal(0D)),
+      FiniteDuration(1L, "second") -> JsString("1 second"),
+      Duration("5seconds") -> JsString("5 seconds"))) { (duration, json) =>
+      Json.toJson(duration) mustEqual json
     }
 
-    "be successful for FiniteDuration" in forAll(Table(
+    "be successful as millis for FiniteDuration" in forAll(Table(
       "duration" -> "json",
-      Duration.Zero -> "0",
-      FiniteDuration(1L, "second") -> "1 second")) { (duration, json) =>
+      Duration.Zero -> 0L,
+      FiniteDuration(1L, "second") -> 1000L
+    )) { (duration, millis) =>
       Json.toJson(duration)(Writes.finiteDurationNumberWrites) mustEqual (
-        JsNumber(duration.toMillis))
+        JsNumber(BigDecimal(millis)))
     }
 
     "be successful for infinite Duration" in forAll(Table(

--- a/play-json/shared/src/test/scala/WritesSharedSpec.scala
+++ b/play-json/shared/src/test/scala/WritesSharedSpec.scala
@@ -25,12 +25,20 @@ class WritesSharedSpec extends WordSpec with MustMatchers {
       )
     }
 
-    "be successful for FiniteDuration" in forAll(Table(
+    "be successful for finite Duration" in forAll(Table(
       "duration" -> "json",
       Duration.Zero -> "0",
       FiniteDuration(1L, "second") -> "1 second",
       Duration("5seconds") -> "5 seconds")) { (duration, json) =>
       Json.toJson(duration) mustEqual JsString(json)
+    }
+
+    "be successful for FiniteDuration" in forAll(Table(
+      "duration" -> "json",
+      Duration.Zero -> "0",
+      FiniteDuration(1L, "second") -> "1 second")) { (duration, json) =>
+      Json.toJson(duration)(Writes.finiteDurationNumberWrites) mustEqual (
+        JsNumber(duration.toMillis))
     }
 
     "be successful for infinite Duration" in forAll(Table(

--- a/play-json/shared/src/test/scala/WritesSharedSpec.scala
+++ b/play-json/shared/src/test/scala/WritesSharedSpec.scala
@@ -3,10 +3,13 @@
  */
 package play.api.libs.json
 
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+
 import org.scalatest._
+import org.scalatest.prop.TableDrivenPropertyChecks._
 
 class WritesSharedSpec extends WordSpec with MustMatchers {
-  "Functionnal Reads" should {
+  "Functionnal Writes" should {
     import play.api.libs.functional.syntax._
 
     implicit val locationWrites = Writes[Location] { location =>
@@ -20,6 +23,23 @@ class WritesSharedSpec extends WordSpec with MustMatchers {
       Json.toJson(Location(0.123D, 0.456D)) mustEqual Json.obj(
         "lat" -> 0.123D, "long" -> 0.456D
       )
+    }
+
+    "be successful for FiniteDuration" in forAll(Table(
+      "duration" -> "json",
+      Duration.Zero -> "0",
+      FiniteDuration(1L, "second") -> "1 second",
+      Duration("5seconds") -> "5 seconds")) { (duration, json) =>
+      Json.toJson(duration) mustEqual JsString(json)
+    }
+
+    "be successful for infinite Duration" in forAll(Table(
+      "duration" -> "json",
+      Duration.Inf -> "Inf",
+      Duration.MinusInf -> "MinusInf",
+      Duration.Undefined -> "Undefined"
+    )) { (duration, json) =>
+      Json.toJson(duration) mustEqual JsString(json)
     }
   }
 


### PR DESCRIPTION
Provides `Reads` and `Writes` for Scala durations.

*Writes[Duration]:*

| Duration                     | Json                              |
|---------------------|------------------------|
| Duration.Inf               | JsString("Inf")               |
| Duration.MinusInf     | JsString("MinusInf")     |
| Duration.Zero           | JsNumber(0)                  |
| Duration.Undefined | JsString("Undefined")    |
| _Any finite_               | JsString(finite.toString) |

*Reads[Duration]:*

| Duration                     | Json                              |
|---------------------|------------------------|
| JsString("Inf")      | Duration.Inf       |
| JsString("PlusInf")  | Duration.Inf       |
| JsString("+Inf")     | Duration.Inf       |
| JsString("MinusInf") | Duration.MinusInf |
| JsString("Undefined") | Duration.Undefined |
| JsString("1 second") | Duration("1s") |
| JsNumber(1.234D) | Duration("1234ms") |
| JsNumber(1234) | Duration("1234ms")

*Reads[FiniteDuration]:*

| Duration                     | Json                              |
|---------------------|------------------------|
| JsString("1 second") | Duration("1s") |
| JsNumber(1.234D) | Duration("1234ms") |
| JsNumber(1234) | Duration("1234ms") |