### PR TITLE
Utility to convert JsResult to Try

### DIFF
--- a/play-json/shared/src/main/scala/JsResult.scala
+++ b/play-json/shared/src/main/scala/JsResult.scala
@@ -201,7 +201,7 @@ object JsResult {
   import play.api.libs.functional._
 
   case class Exception(cause: JsError)
-    extends IllegalArgumentException(Json stringify JsError.toJson(cause))
+    extends java.lang.Exception(Json stringify JsError.toJson(cause))
     with scala.util.control.NoStackTrace
 
   /**

--- a/play-json/shared/src/main/scala/JsResult.scala
+++ b/play-json/shared/src/main/scala/JsResult.scala
@@ -197,7 +197,32 @@ sealed trait JsResult[+A] { self =>
 }
 
 object JsResult {
+  import scala.util.{ Failure, Try, Success }
   import play.api.libs.functional._
+
+  case class Exception(cause: JsError)
+    extends IllegalArgumentException(Json stringify JsError.toJson(cause))
+    with scala.util.control.NoStackTrace
+
+  /**
+   * Returns a JSON validation as a [[scala.util.Try]].
+   *
+   * @tparam T the type for the parsing
+   * @param result the JSON validation result
+   * @param err the function to be applied if the results is an error
+   *
+   * {{{
+   * import scala.concurrent.Future
+   * import play.api.libs.json.JsResult
+   *
+   * def toFuture[T](res: JsResult[T]): Future[T] =
+   *   Future.fromTry(JsResult.toTry(res))
+   * }}}
+   */
+  def toTry[T](result: JsResult[T], err: JsError => Throwable = Exception(_)): Try[T] = result match {
+    case e @ JsError(_) => Failure(err(e))
+    case s @ JsSuccess(v, _) => Success(v)
+  }
 
   implicit def alternativeJsResult(implicit a: Applicative[JsResult]): Alternative[JsResult] = new Alternative[JsResult] {
     val app = a

--- a/play-json/shared/src/test/scala/JsResultSpec.scala
+++ b/play-json/shared/src/test/scala/JsResultSpec.scala
@@ -3,6 +3,8 @@
  */
 package play.api.libs.json
 
+import scala.util.{ Failure, Success }
+
 import play.api.libs.functional.Functor
 
 import JsResult.functorJsResult
@@ -18,6 +20,15 @@ class JsResultSpec extends WordSpec with MustMatchers {
         fmap[String, List[Char]](jsres, _.toList).mustEqual(
           JsSuccess(List('j', 's', 'S', 't', 'r'))
         )
+    }
+
+    "be converted to Success" in {
+      JsResult.toTry(JsSuccess("foo")) mustEqual Success("foo")
+    }
+
+    "be converted to basic Failure" in {
+      val err = JsError("bar")
+      JsResult.toTry(err) mustEqual Failure(JsResult.Exception(err))
     }
   }
 }


### PR DESCRIPTION
```scala
def foo[T](res: JsResult[T]): Try[T] = JsResult.toTry(res)
def bar[T](res: JsResult[T]): Future[T] = Future.fromTry(JsResult.toTry(res))
```