### PR TITLE
Codecs for Java TemporalAmount

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
@@ -377,7 +377,7 @@ trait EnvReads {
         case JsNumber(d) => JsSuccess(epoch(d.toLong))
         case JsString(s) => p(parsing).parse(corrector(s)) match {
           case Some(d) => JsSuccess(d)
-          case None => JsError(Seq(JsPath ->
+          case _ => JsError(Seq(JsPath ->
             Seq(JsonValidationError("error.expected.date.isoformat", parsing))))
         }
         case _ => JsError(Seq(JsPath ->
@@ -445,7 +445,7 @@ trait EnvReads {
         case JsNumber(d) => JsSuccess(epoch(d.toLong))
         case JsString(s) => p(parsing).parse(corrector(s)) match {
           case Some(d) => JsSuccess(d)
-          case None => JsError(Seq(JsPath ->
+          case _ => JsError(Seq(JsPath ->
             Seq(JsonValidationError("error.expected.date.isoformat", parsing))))
         }
         case _ => JsError(Seq(JsPath ->
@@ -538,7 +538,7 @@ trait EnvReads {
         JsError("error.invalid.longDuration")
 
       case JsNumber(n) => JsSuccess(JDuration.of(n.toLong, unit))
-      case _ => JsError("error.expected.duration")
+      case _ => JsError("error.expected.lonDuration")
     }
 
   /**
@@ -561,7 +561,7 @@ trait EnvReads {
     case JsString(repr) => try {
       JsSuccess(JDuration.parse(repr))
     } catch {
-      case _: Exception => JsError("error.invalid.duration")
+      case _: DateTimeParseException => JsError("error.invalid.duration")
     }
 
     case js => javaDurationMillisReads.reads(js)
@@ -646,7 +646,7 @@ trait EnvReads {
     def reads(json: JsValue): JsResult[LocalDate] = json match {
       case JsString(s) => parseDate(corrector(s)) match {
         case Some(d) => JsSuccess(d)
-        case None => JsError(Seq(JsPath() -> Seq(JsonValidationError("error.expected.jodadate.format", pattern))))
+        case _ => JsError(Seq(JsPath() -> Seq(JsonValidationError("error.expected.jodadate.format", pattern))))
       }
       case _ => JsError(Seq(JsPath() -> Seq(JsonValidationError("error.expected.date"))))
     }

--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
@@ -592,7 +592,7 @@ trait EnvReads {
     case JsString(repr) => try {
       JsSuccess(Period.parse(repr))
     } catch {
-      case _: Exception => JsError("error.invalid.stringPeriod")
+      case _: DateTimeParseException => JsError("error.invalid.stringPeriod")
     }
 
     case js => javaPeriodDaysReads.reads(js)
@@ -615,7 +615,7 @@ trait EnvReads {
       case JsNumber(d) => JsSuccess(new DateTime(d.toLong))
       case JsString(s) => parseDate(corrector(s)) match {
         case Some(d) => JsSuccess(d)
-        case None => JsError(Seq(JsPath() -> Seq(JsonValidationError("error.expected.jodadate.format", pattern))))
+        case _ => JsError(Seq(JsPath() -> Seq(JsonValidationError("error.expected.jodadate.format", pattern))))
       }
       case _ => JsError(Seq(JsPath() -> Seq(JsonValidationError("error.expected.date"))))
     }

--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
@@ -8,7 +8,9 @@ import java.util.Locale
 import java.time.format.DateTimeFormatter
 import java.time.temporal.Temporal
 import java.time.{
+  Duration => JDuration,
   Instant,
+  Period,
   LocalDate,
   LocalTime,
   LocalDateTime,
@@ -304,6 +306,24 @@ trait EnvWrites {
       JsObject(fields.result())
     }
   }
+
+  /** Serializer of Java Duration as a number of milliseconds. */
+  val javaDurationMillisWrites: Writes[JDuration] =
+    Writes[JDuration] { d => JsNumber(d.toMillis) }
+
+  /**
+   * Serializer of Java Duration using ISO representation
+   * (e.g. PT1S for 1 second).
+   */
+  implicit val javaDurationWrites: Writes[JDuration] =
+    Writes[JDuration] { d => JsString(d.toString) }
+
+  /**
+   * Serializer of Java Period using ISO representation
+   * (e.g. P2D for 2 days).
+   */
+  implicit val javaPeriodWrites: Writes[Period] =
+    Writes[Period] { d => JsString(d.toString) }
 
   // TODO: Move to a separate module + deprecation
   import org.joda.time.{ DateTime, LocalDate, LocalTime }

--- a/play-json/shared/src/main/scala/Json.scala
+++ b/play-json/shared/src/main/scala/Json.scala
@@ -126,11 +126,11 @@ sealed trait JsonFacade {
   /**
    * Converts any object writeable value to a [[JsObject]].
    *
-   * A value is object writeable if a [[OWrites]] implicit is available for
-   * its type.
+   * A value is writeable as an object,
+   * if a [[OWrites]] implicit is available for its type.
    *
-   * @tparam T the type of the value to be written as JsObject
-   * @param o the value to convert as JsObject
+   * @tparam T the type of the value to be written as `JsObject`
+   * @param o the value to convert as JSON object
    */
   def toJsObject[T](o: T)(implicit tjs: OWrites[T]): JsObject
 

--- a/play-json/shared/src/main/scala/Reads.scala
+++ b/play-json/shared/src/main/scala/Reads.scala
@@ -29,8 +29,7 @@ trait Reads[A] { self =>
    * @param f the function applied on the result of the current instance,
    * if successful
    */
-  def map[B](f: A => B): Reads[B] =
-    Reads[B] { json => self.reads(json).map(f) }
+  def map[B](f: A => B): Reads[B] = Reads[B] { self.reads(_).map(f) }
 
   def flatMap[B](f: A => Reads[B]): Reads[B] = Reads[B] { json =>
     // Do not flatMap result to avoid repath
@@ -40,8 +39,7 @@ trait Reads[A] { self =>
     }
   }
 
-  def filter(f: A => Boolean): Reads[A] =
-    Reads[A] { json => self.reads(json).filter(f) }
+  def filter(f: A => Boolean): Reads[A] = Reads[A] { self.reads(_).filter(f) }
 
   def filter(error: JsonValidationError)(f: A => Boolean): Reads[A] =
     Reads[A] { json => self.reads(json).filter(JsError(error))(f) }


### PR DESCRIPTION
Support Java Time `Duration` (see #40 ) and `Period`, either as number (by default of millis of `Duration` or of `days` for `Period`), or as ISO string representation.