### PR TITLE
Add toJsObject method to Json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ def jsonDependencies(scalaVersion: String) = Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion
 )
 
-// Common settings 
+// Common settings
 import com.typesafe.sbt.SbtScalariform._
 import scalariform.formatter.preferences._
 
@@ -112,6 +112,7 @@ lazy val `play-json` = crossProject.crossType(CrossType.Full)
     libraryDependencies ++= jsonDependencies(scalaVersion.value) ++ Seq(
       "org.scalatest" %%% "scalatest" % "3.0.0" % Test,
       "org.scalacheck" %%% "scalacheck" % "1.13.4" % Test,
+      "com.chuusai" %% "shapeless" % "2.3.2" % Test,
       "org.typelevel" %% "macro-compat" % "1.1.1",
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/play-json/shared/src/main/scala/Json.scala
+++ b/play-json/shared/src/main/scala/Json.scala
@@ -124,6 +124,17 @@ sealed trait JsonFacade {
   def toJson[T](o: T)(implicit tjs: Writes[T]): JsValue
 
   /**
+   * Converts any object writeable value to a [[JsObject]].
+   *
+   * A value is object writeable if a [[OWrites]] implicit is available for
+   * its type.
+   *
+   * @tparam T the type of the value to be written as JsObject
+   * @param o the value to convert as JsObject
+   */
+  def toJsObject[T](o: T)(implicit tjs: OWrites[T]): JsObject
+
+  /**
    * Converts a [[JsValue]] to a value of requested type `T`.
    *
    * @tparam T The type of conversion result,
@@ -173,6 +184,8 @@ object Json extends JsonFacade {
   def prettyPrint(json: JsValue): String = StaticBinding.prettyPrint(json)
 
   def toJson[T](o: T)(implicit tjs: Writes[T]): JsValue = tjs.writes(o)
+
+  def toJsObject[T](o: T)(implicit tjs: OWrites[T]): JsObject = tjs.writes(o)
 
   def fromJson[T](json: JsValue)(implicit fjs: Reads[T]): JsResult[T] = fjs.reads(json)
 
@@ -301,6 +314,9 @@ object Json extends JsonFacade {
     @inline def prettyPrint(json: JsValue): String = Json.prettyPrint(json)
     @inline def toJson[T](o: T)(implicit tjs: Writes[T]): JsValue =
       Json.toJson[T](o)
+
+    @inline def toJsObject[T](o: T)(implicit tjs: OWrites[T]): JsObject =
+      Json.toJsObject[T](o)
 
     @inline def fromJson[T](json: JsValue)(implicit fjs: Reads[T]): JsResult[T] = Json.fromJson[T](json)
 

--- a/play-json/shared/src/test/scala/JsonSharedSpec.scala
+++ b/play-json/shared/src/test/scala/JsonSharedSpec.scala
@@ -123,6 +123,16 @@ class JsonSharedSpec extends WordSpec
       js.toJson(mario).as[User] mustEqual mario
     }
 
+    "convert to a json object" in json { js =>
+      val peach = User(1, "Peach", List())
+      val writes: Writes[User] = Json.writes[User]
+      val owrites: OWrites[User] = Json.writes[User]
+
+      js.toJsObject(peach)(owrites) mustBe an[JsObject]
+      js.toJsObject(peach)(owrites) mustEqual js.toJson(peach)(writes)
+      shapeless.test.illTyped("js.toJsObject(peach)(writes)")
+    }
+
     "convert to a byte array containing the UTF-8 representation" in json { js =>
       val json = js.parse(
         """

--- a/play-json/shared/src/test/scala/JsonSharedSpec.scala
+++ b/play-json/shared/src/test/scala/JsonSharedSpec.scala
@@ -130,6 +130,7 @@ class JsonSharedSpec extends WordSpec
 
       js.toJsObject(peach)(owrites) mustBe an[JsObject]
       js.toJsObject(peach)(owrites) mustEqual js.toJson(peach)(writes)
+      shapeless.test.illTyped("js.toJsObject(1)")
       shapeless.test.illTyped("js.toJsObject(peach)(writes)")
     }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

Convert values which type has `OWrites` typeclass to a `JsObject` with `Json.toJsObject`.

## Use case

Convert a value to a `JsObject` and add a `(key, value)` pair to the generated `JsObject`.