### PR TITLE
Add "joda-convert" dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,8 @@ val jacksons = Seq(
 ).map(_ % jacksonVersion)
 
 val joda = Seq(
-  "joda-time" % "joda-time" % "2.9.6"
-    //"org.joda" % "joda-convert" % "1.8.1")
+  "joda-time" % "joda-time" % "2.9.6",
+  "org.joda" % "joda-convert" % "1.8.1"
 )
 
 def jsonDependencies(scalaVersion: String) = Seq(


### PR DESCRIPTION
Consider adding `joda-convert` dependency (actually restoring, because it [is present in Play! 2.5.x](https://github.com/playframework/playframework/blob/2.5.13/framework/project/Dependencies.scala#L113))

When building project using `play-json` there are warnings, like these:
```
[warn] Class org.joda.convert.FromString not found - continuing with a stub.
[warn] Class org.joda.convert.ToString not found - continuing with a stub.
```

[Here](https://github.com/JodaOrg/joda-time/blob/master/RELEASE-NOTES.txt#L22-L26) is a note about it in `joda-time` project.

Sample project - [Scala Slick example for Play! 2.6.x](https://github.com/playframework/play-scala-slick-example/tree/SNAPSHOT) (see warnings in [Travis build](https://travis-ci.org/playframework/play-scala-slick-example/builds/205153642#L575-L581)).

Even `play-json` builds emit these warnings. E.g. `2.6.0-M5` build in Travis:
- [Travis build for Scala 2.10](https://travis-ci.org/playframework/play-json/jobs/209809231#L423-L433)
- [Travis build for Scala 2.11](https://travis-ci.org/playframework/play-json/jobs/209809230#L473-L481)

What's interesting, builds for Scala 2.12 do not emit these warnings. Something was improved in 2.12.
