### PR TITLE
extends Function1 for convenience and 2.5.x compatibility

### DIFF
--- a/play-json/shared/src/main/scala/JsValue.scala
+++ b/play-json/shared/src/main/scala/JsValue.scala
@@ -111,7 +111,7 @@ case class JsArray(value: Seq[JsValue] = List()) extends JsValue {
   def prepend(el: JsValue): JsArray = this.+:(el)
 }
 
-object JsArray {
+object JsArray extends scala.runtime.AbstractFunction1[Seq[JsValue], JsArray] {
   def empty = JsArray(Seq.empty)
 }
 
@@ -196,7 +196,7 @@ case class JsObject(
   override def hashCode: Int = fieldSet.hashCode()
 }
 
-object JsObject {
+object JsObject extends scala.runtime.AbstractFunction1[Seq[(String, JsValue)], JsObject] {
   /**
    * Construct a new JsObject, with the order of fields in the Seq.
    */


### PR DESCRIPTION
2.5.x

```scala
val foo: Option[Seq[JsValue]] = None
foo.map(JsArray) // success
```

2.6.0-M6

```scala
val foo: Option[Seq[JsValue]] = None
foo.map(JsArray) // compile error
foo.map(JsArray(_)) // need (_)
```

http://stackoverflow.com/a/3054165
