### PR TITLE
Fix Reads[Map[K,V]] succeeding when keys are invalid

### DIFF
--- a/play-json/shared/src/test/scala/ReadsSharedSpec.scala
+++ b/play-json/shared/src/test/scala/ReadsSharedSpec.scala
@@ -39,9 +39,19 @@ class ReadsSharedSpec extends WordSpec with MustMatchers {
           JsSuccess(Map("foo" -> 1, "bar" -> 2)))
     }
 
-    "be successfully read with character keys" in {
-      Json.fromJson[Map[Char, Int]](Json.obj("a" -> 1, "b" -> 2))(
-        Reads.charMapReads) mustEqual JsSuccess(Map('a' -> 1, 'b' -> 2))
+    "be read with character keys" which {
+      "are characters" in {
+        Json.fromJson[Map[Char, Int]](Json.obj("a" -> 1, "b" -> 2))(
+          Reads.charMapReads) mustEqual JsSuccess(Map('a' -> 1, 'b' -> 2))
+      }
+
+      "are not characters" in {
+        Json.fromJson[Map[Char, Int]](Json.obj("foo" -> 1, "bar" -> 2))(
+          Reads.charMapReads) mustEqual JsError(List(
+          (JsPath \ "foo", List(JsonValidationError("error.invalid.character"))),
+          (JsPath \ "bar", List(JsonValidationError("error.invalid.character")))
+        ))
+      }
     }
   }
 


### PR DESCRIPTION
Parsing `{ "foo": "bar", "a": "b" }` as a `Map[Char, String]` will result in `obj("a" -> "b")`, silently dropping the invalid key from the map. I think you should get a `JsError` instead.

The change was introduced in #44. It appears to be unintentional: `acc.left.map { ... }` is a no-op (discarding the error) since `acc` is known to be a `Right`.

https://github.com/playframework/play-json/blob/master/play-json/shared/src/main/scala/Reads.scala#L398-L402