### PR TITLE
Standardize/Fix behavior of JsLookup#apply and JsLookup#\

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ val lat = (json \ "location" \ "lat").get
 
 The `(json \ "location" \ "lat")` returns a `JsLookupResult` which may or may not contain a value. Note that the `get` operation is not always safe; it throws an exception if the path doesn't exist.
 
+You can also use `\` to look up indices within a `JsArray`:
+
+```scala
+val bigwig = (json \ "residents" \ 1).get
+// returns {"name":"Bigwig","age":6,"role":"Owsla"}
+```
+
 ### Recursive path \\
 Applying the `\\` operator will do a lookup for the field in the current object and all descendants.
 
@@ -81,15 +88,18 @@ val names = json \\ "name"
 // returns Seq(JsString("Watership Down"), JsString("Fiver"), JsString("Bigwig"))
 ```
 
-### Index lookup (for JsArrays)
-You can retrieve a value in a JsArray using an apply operator with the index number.
+### Index lookup
+You can retrieve a value in a JsObject or JsArray using an apply operator with the index number or key.
 
 ```scala
-val bigwig = (json \ "residents")(1)
+val name = json("name")
+// returns JsString("Watership Down")
+
+val bigwig = json("residents")(1)
 // returns {"name":"Bigwig","age":6,"role":"Owsla"}
 ```
 
-Like `get`, this operation will throw an exception if the index doesn't exist. Use `validate` or one of the other methods described below to handle the result more safely.
+Like `get`, this will throw an exception if the index doesn't exist. Use the Simple Path `\` operator and `validate` or `asOpt` (described below) if you expect that they key may not be present.
 
 ## Reading and writing objects
 
@@ -116,6 +126,13 @@ val nameResult = (json \ "name").validate[String]
 
 val bogusResult = (json \ "bogus").validate[String]
 // JsError
+
+val unsafeName2 = json("name").as[String]
+// "Watership Down"
+
+val unsafeBogusName2 = json("bogus").as[String]
+// throws exception
+
 ```
 
 ### Automatic conversion

--- a/docs/manual/working/scalaGuide/main/json/ScalaJson.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJson.md
@@ -101,9 +101,14 @@ You can traverse a `JsValue` structure and extract specific values. The syntax a
 
 ### Simple path `\`
 
-Applying the `\` operator to a `JsValue` will return the property corresponding to the field argument, supposing this is a `JsObject`.
+Applying the `\` operator to a `JsValue` will return the property corresponding to the field argument in a `JsObject`, or the item at that index in a `JsArray`
 
 @[traverse-simple-path](code/ScalaJsonSpec.scala)
+
+
+The `\` operator returns a `JsLookupResult`, which is either `JsDefined` or `JsUndefined`. You can chain multiple `\` operators, and the result will be `JsUndefined` if any intermediate value cannot be found. Calling `get` on a `JsLookupResult` attempts to get the value if it is defined and throws an exception if it is not.
+
+You can also use the Direct lookup `apply` method (below) to get a field in an object or index in an array. Like `get`, this method will throw an exception if the value does not exist.
 
 ### Recursive path `\\`
 
@@ -111,11 +116,13 @@ Applying the `\\` operator will do a lookup for the field in the current object 
 
 @[traverse-recursive-path](code/ScalaJsonSpec.scala)
 
-### Index lookup (for JsArrays)
+### Direct lookup
 
-You can retrieve a value in a `JsArray` using an apply operator with the index number.
+You can retrieve a value in a `JsArray` or `JsObject` using an `.apply` operator, which is identical to the Simple path `\` operator except it returns the value directly (rather than wrapping it in a `JsLookupResult`) and throws an exception if the index or key is not found:
 
 @[traverse-array-index](code/ScalaJsonSpec.scala)
+
+This is useful if you are writing quick-and-dirty code and are accessing some JSON values you *know* to exist, for example in one-off scripts or in the REPL.
 
 ## Converting from a JsValue
 

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
@@ -4,6 +4,7 @@
 package scalaguide.json
 
 import org.specs2.mutable.Specification
+import play.api.libs.json.{JsNumber, JsString, Json}
 
 class ScalaJsonSpec extends Specification {
 
@@ -213,7 +214,16 @@ class ScalaJsonSpec extends Specification {
       //#traverse-simple-path
       val lat = (json \ "location" \ "lat").get
       // returns JsNumber(51.235685)
+      val bigwig = (json \ "residents" \ 1).get
+      // returns {"name":"Bigwig","age":6,"role":"Owsla"}
+
       //#traverse-simple-path
+
+      val expected = Json.parse(
+        """{"name":"Bigwig","age":6,"role":"Owsla"}"""
+      )
+      bigwig mustEqual expected
+
 
       lat === JsNumber(51.235685)
 
@@ -224,9 +234,46 @@ class ScalaJsonSpec extends Specification {
       names === Seq(JsString("Watership Down"), JsString("Fiver"), JsString("Bigwig"))
 
       //#traverse-array-index
-      val bigwig = (json \ "residents")(1)
+      val name = json("name")
+      // returns JsString("Watership Down")
+
+      val bigwig2 = json("residents")(1)
       // returns {"name":"Bigwig","age":6,"role":"Owsla"}
+
+      // (json("residents")(3)
+      // throws an IndexOutOfBoundsException
+
+      // json("bogus")
+      // throws a NoSuchElementException
       //#traverse-array-index
+
+      name mustEqual JsString("Watership Down")
+
+      val expected2 = Json.parse(
+        """{"name":"Bigwig","age":6,"role":"Owsla"}"""
+      )
+      bigwig2 mustEqual expected2
+
+      try {
+        json("residents")(3)
+        assert(false)
+      } catch { case e: IndexOutOfBoundsException =>
+        assert(e.getMessage == "3")
+      }
+      try {
+        json("residents")(5)
+        assert(false)
+      } catch { case e: IndexOutOfBoundsException =>
+        assert(e.getMessage == "5")
+      }
+
+      try {
+        json("bogus")
+        assert(false)
+      } catch { case e: NoSuchElementException =>
+
+      }
+
       (bigwig \ "name").get === JsString("Bigwig")
     }
 

--- a/play-json/shared/src/main/scala/JsLookup.scala
+++ b/play-json/shared/src/main/scala/JsLookup.scala
@@ -43,20 +43,47 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    *
    * @param index Element index.
    */
-  def apply(index: Int): JsLookupResult = result match {
+  def apply(index: Int): JsValue = result match {
+    case JsDefined(x) => x match {
+      case arr: JsArray => arr.value.lift(index) match {
+        case Some(x) => x
+        case None => throw new IndexOutOfBoundsException(String.valueOf(index))
+      }
+      case _ =>
+        throw new Exception(x + " is not a JsArray")
+    }
+    case x: JsUndefined =>
+      throw new Exception(String.valueOf(x.error))
+  }
+  /**
+   * Access a value of this array.
+   *
+   * @param fieldName Element index.
+   */
+  def apply(fieldName: String): JsValue = result match {
+    case JsDefined(x) => x match {
+      case arr: JsObject => arr.value.lift(fieldName) match {
+        case Some(x) => x
+        case None => throw new NoSuchElementException(String.valueOf(fieldName))
+      }
+      case _ =>
+        throw new Exception(x + " is not a JsObject")
+    }
+    case x: JsUndefined =>
+      throw new Exception(String.valueOf(x.error))
+  }
+  /**
+   * Access a value of this array.
+   *
+   * @param index Element index
+   */
+  def \(index: Int): JsLookupResult = result match {
     case JsDefined(arr: JsArray) =>
       arr.value.lift(index).map(JsDefined.apply).getOrElse(JsUndefined(s"Array index out of bounds in $arr"))
     case JsDefined(o) =>
       JsUndefined(s"$o is not an array")
     case undef => undef
   }
-
-  /**
-   * Access a value of this array.
-   *
-   * @param index Element index
-   */
-  def \(index: Int): JsLookupResult = apply(index)
 
   /**
    * Return the property corresponding to the fieldName, supposing we have a JsObject.

--- a/play-json/shared/src/main/scala/JsPath.scala
+++ b/play-json/shared/src/main/scala/JsPath.scala
@@ -94,7 +94,7 @@ case class KeyPathNode(key: String) extends PathNode {
 
 case class IdxPathNode(idx: Int) extends PathNode {
   def apply(json: JsValue): List[JsValue] = json match {
-    case arr: JsArray => List(arr(idx)).flatMap(_.toOption)
+    case arr: JsArray => List(arr \ idx).flatMap(_.toOption)
     case _ => List()
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

I don't see an open issue for this

## Purpose

- Fix behavior of `JsLookup#apply(index: Int)` to properly throw exceptions, as is already described in the readme.

- Add a `JsLookup#apply(fieldName: String)` which similarly throws exceptions if the key is not found, for consistency with `JsLookup#apply(index: Int)` and `JsLookup#\(index: Int)` and `JsLookup#\(fieldName: String)`

- Convert an internal callsite from `JsLookup#apply(index: Int)` to `JsLookup#\(index: Int)`, since that callsite seems to want the don't-throw-exception behavior

- Document behavior of existing `JsLookup#\(index: Int)` and new `JsLookup#apply(fieldName: String)` in the readme

- Add tests for:

    - The existing `JsLookup#apply(index: Int)` to ensure it throws exceptions as is described in the readme,
    - The new `JsLookup#apply(fieldName: String)` operation

## Background Context

- `JsLookup#apply(index: Int)` was a simple alias for `JsLookup#\(index: Int)`, which meant it wasn't throwing which is what the existing readme said it should be doing

- If we have both exception-throwing and non-exception-throwing ways of looking up `JsArrays` by `index: Int`, it makes sense to have the same two ways of looking up `JsObjects` by `fieldName: String`

I haven't discussed this with anyone, but given the existing code and the existing behavior the readme describes, this seems like the right thing to do. Tests seem to pass, though the old incorrect-according-to-readme behavior of `JsLookup#apply(index: Int)` didn't appear to be tested anywhere so the change in semantics didn't break anything until I added my own tests.

Let me know what you think...

## References