### PR TITLE
Make `JsArray` take an `IndexedSeq` instead of a `Seq`

### DIFF
--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
@@ -56,7 +56,7 @@ class ScalaJsonSpec extends Specification {
       val json: JsValue = JsObject(Seq(
         "name" -> JsString("Watership Down"),
         "location" -> JsObject(Seq("lat" -> JsNumber(51.235685), "long" -> JsNumber(-1.309197))),
-        "residents" -> JsArray(Seq(
+        "residents" -> JsArray(IndexedSeq(
           JsObject(Seq(
             "name" -> JsString("Fiver"),
             "age" -> JsNumber(4),

--- a/play-json/js/src/main/scala/StaticBinding.scala
+++ b/play-json/js/src/main/scala/StaticBinding.scala
@@ -108,7 +108,7 @@ object StaticBinding {
     case l: Long => JsNumber(l)
     case true => JsTrue
     case false => JsFalse
-    case a: js.Array[_] => JsArray(a.map(anyToJsValue).toSeq)
+    case a: js.Array[_] => JsArray(a.map(anyToJsValue).toArray[JsValue])
 
     case o: js.Object => {
       JsObject((for {

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -17,7 +17,8 @@ import com.fasterxml.jackson.databind.ser.Serializers
 import play.api.libs.json._
 
 import scala.annotation.{ switch, tailrec }
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable
+import scala.collection.mutable.{ ArrayBuffer, ListBuffer }
 
 /**
  * The Play JSON module for Jackson.
@@ -99,7 +100,7 @@ private[jackson] sealed trait DeserializerContext {
   def addValue(value: JsValue): DeserializerContext
 }
 
-private[jackson] case class ReadingList(content: ListBuffer[JsValue]) extends DeserializerContext {
+private[jackson] case class ReadingList(content: mutable.ArrayBuffer[JsValue]) extends DeserializerContext {
   override def addValue(value: JsValue): DeserializerContext = {
     ReadingList(content += value)
   }
@@ -149,7 +150,7 @@ private[jackson] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]
 
       case JsonTokenId.ID_NULL => (Some(JsNull), parserContext)
 
-      case JsonTokenId.ID_START_ARRAY => (None, ReadingList(ListBuffer()) +: parserContext)
+      case JsonTokenId.ID_START_ARRAY => (None, ReadingList(ArrayBuffer()) +: parserContext)
 
       case JsonTokenId.ID_END_ARRAY => parserContext match {
         case ReadingList(content) :: stack => (Some(JsArray(content)), stack)

--- a/play-json/shared/src/main/scala/JsResult.scala
+++ b/play-json/shared/src/main/scala/JsResult.scala
@@ -108,12 +108,12 @@ object JsError {
     errors.foldLeft(JsObject.empty) { (obj, error) =>
       obj ++ JsObject(Seq(error._1.toJsonString -> error._2.foldLeft(JsArray.empty) { (arr, err) =>
         val msg = JsArray({
-          if (flat) Seq(JsString(err.message))
-          else err.messages.map(JsString(_))
+          if (flat) Array(JsString(err.message))
+          else err.messages.map(JsString(_)).toArray[JsValue]
         })
         arr :+ JsObject(Seq(
           "msg" -> msg,
-          "args" -> JsArray(err.args.map(toJson))
+          "args" -> JsArray(err.args.map(toJson).toArray[JsValue])
         ))
       }))
     }

--- a/play-json/shared/src/main/scala/JsValue.scala
+++ b/play-json/shared/src/main/scala/JsValue.scala
@@ -90,7 +90,7 @@ case class JsString(value: String) extends JsValue
 /**
  * Represent a Json array value.
  */
-case class JsArray(value: Seq[JsValue] = List()) extends JsValue {
+case class JsArray(value: IndexedSeq[JsValue] = Array[JsValue]()) extends JsValue {
 
   /**
    * Concatenates this array with the elements of an other array.
@@ -111,8 +111,10 @@ case class JsArray(value: Seq[JsValue] = List()) extends JsValue {
   def prepend(el: JsValue): JsArray = this.+:(el)
 }
 
-object JsArray extends scala.runtime.AbstractFunction1[Seq[JsValue], JsArray] {
-  def empty = JsArray(Seq.empty)
+object JsArray extends scala.runtime.AbstractFunction1[IndexedSeq[JsValue], JsArray] {
+  def apply(value: Seq[JsValue]) = new JsArray(value.toArray[JsValue])
+
+  def empty = JsArray(Array.empty[JsValue])
 }
 
 /**

--- a/play-json/shared/src/main/scala/Json.scala
+++ b/play-json/shared/src/main/scala/Json.scala
@@ -217,7 +217,7 @@ object Json extends JsonFacade {
   def obj(fields: (String, JsValueWrapper)*): JsObject = JsObject(fields.map(f => (f._1, f._2.asInstanceOf[JsValueWrapperImpl].field)))
 
   def arr(items: JsValueWrapper*): JsArray =
-    JsArray(items.map(_.asInstanceOf[JsValueWrapperImpl].field))
+    JsArray(items.iterator.map(_.asInstanceOf[JsValueWrapperImpl].field).toArray[JsValue])
 
   import language.experimental.macros
 

--- a/play-json/shared/src/main/scala/Reads.scala
+++ b/play-json/shared/src/main/scala/Reads.scala
@@ -128,7 +128,7 @@ object Reads extends ConstraintReads with PathReads with DefaultReads {
     def identity = JsArray()
   }
 
-  implicit val JsArrayReducer = Reducer[JsValue, JsArray](js => JsArray(Seq(js)))
+  implicit val JsArrayReducer = Reducer[JsValue, JsArray](js => JsArray(Array(js)))
 }
 
 /**

--- a/play-json/shared/src/main/scala/Writes.scala
+++ b/play-json/shared/src/main/scala/Writes.scala
@@ -190,7 +190,7 @@ trait DefaultWrites extends LowPriorityWrites {
   implicit def arrayWrites[T: ClassTag: Writes]: Writes[Array[T]] = {
     val w = implicitly[Writes[T]]
 
-    Writes[Array[T]] { ts => JsArray(ts.map(w.writes(_)).toSeq) }
+    Writes[Array[T]] { ts => JsArray(ts.map(w.writes(_)).toArray[JsValue]) }
   }
 
   /**
@@ -264,7 +264,7 @@ sealed trait LowPriorityWrites extends EnvWrites {
   implicit def traversableWrites[A: Writes] = {
     val w = implicitly[Writes[A]]
 
-    Writes[Traversable[A]] { as => JsArray(as.map(w.writes(_)).toSeq) }
+    Writes[Traversable[A]] { as => JsArray(as.map(w.writes(_)).toArray[JsValue]) }
     // Avoid resolution ambiguity with more specific Traversable Writes,
     // such as OWrites.map
   }

--- a/play-json/shared/src/test/scala/JsonRichSpec.scala
+++ b/play-json/shared/src/test/scala/JsonRichSpec.scala
@@ -30,7 +30,7 @@ class JsonRichSpec extends WordSpec with MustMatchers {
           )),
           "key2" -> JsNumber(123),
           "key3" -> JsTrue,
-          "key4" -> JsArray(Seq(
+          "key4" -> JsArray(Array(
             JsString("value41"), JsNumber(345.6),
             JsString("test"), JsObject(Seq("key411" -> JsObject(Seq("key4111" -> JsNumber(987.654)))))
           ))

--- a/play-json/shared/src/test/scala/JsonSharedSpec.scala
+++ b/play-json/shared/src/test/scala/JsonSharedSpec.scala
@@ -240,10 +240,10 @@ class JsonSharedSpec extends WordSpec
       val recursiveJson = """{"foo": {"foo":["bar"]}, "bar": {"foo":["bar"]}}"""
       val expectedJson = JsObject(List(
         "foo" -> JsObject(List(
-          "foo" -> JsArray(List[JsValue](JsString("bar")))
+          "foo" -> JsArray(Array[JsValue](JsString("bar")))
         )),
         "bar" -> JsObject(List(
-          "foo" -> JsArray(List[JsValue](JsString("bar")))
+          "foo" -> JsArray(Array[JsValue](JsString("bar")))
         ))
       ))
 
@@ -255,7 +255,7 @@ class JsonSharedSpec extends WordSpec
     }
 
     "can parse null values in Array" in json { js =>
-      js.parse("[null]") mustEqual JsArray(List(JsNull))
+      js.parse("[null]") mustEqual JsArray(Array(JsNull))
     }
 
     "null root object should be parsed as JsNull" in json { js =>

--- a/play-json/shared/src/test/scala/JsonValidSharedSpec.scala
+++ b/play-json/shared/src/test/scala/JsonValidSharedSpec.scala
@@ -101,7 +101,6 @@ class JsonValidSharedSpec extends WordSpec with MustMatchers {
         ))
       )
     }
-
     "validate JsArray of stream to List" in {
       JsArray(Stream("alpha", "beta", "delta") map JsString.apply).validate[List[String]] mustEqual (JsSuccess(List("alpha", "beta", "delta")))
     }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Didn't find any open issue

## Purpose

This should make performance and memory characteristis much
more predictable. Before this diff, the following two lines of
"equivalent" code result in hugely different memory characteristics:

```scala
// 240mb
val json = Json.parse("[" + Array.fill(10000000)("true").mkString(",") + "]")

// 40mb
val json = Json.arr(Array.fill(10000000)(true: Json.JsValueWrapper):_*)
```

And performance characteristics:

```scala
val json = Json.parse("[" + Array.fill(10000)("true").mkString(",") + "]")
val start = System.currentTimeMillis()
var i = 0
while(i < 1000000){ json(9999); i += 1}
println(System.currentTimeMillis() - start) // 69405
```
```scala
val json = Json.arr(Array.fill(10000)(true: Json.JsValueWrapper):_*)
val json = Json.parse("[" + Array.fill(10000)("true").mkString(",") + "]")
val start = System.currentTimeMillis()
var i = 0
while(i < 1000000){ json(9999); i += 1}
println(System.currentTimeMillis() - start) // 172
```

While this is not a problem if we only expect to ever iterate over and
transform a `JsArray`, a user might expect to keep `JsArray`s in memory,
and likely expects to be able to index into them in constant time. After
all, that is possible in most JSON implementations, and the name "JsARRAY"
also hints that you should be able to look things up quickly.

With this diff, both cases behave identically, with low ~40mb memory usage
in the memory benchmark and fast 100-200ms performance in the lookup
benchmark.

We implement some of the `IndexedSeq`s using `Array`s and others using
`mutable.ArrayBuffer`s. There's still going to be some variation in
runtime characteristics, but I think it's probably
fine since it's a constant-time difference in terms of memory usage and
runtime performance. If we really cared, we could make sure to transform
everything into wrapped `Array`s before storing them.

The only casualties I found were the `Stream -> JsArray` tests:

```scala
    "validate JsArray of stream to List" in {
      JsArray(Stream("alpha", "beta", "delta") map JsString.apply).validate[List[String]] mustEqual (JsSuccess(List("alpha", "beta", "delta")))
    }

    "invalidate JsArray of stream to List with wrong type conversion" in {
      JsArray(Stream(JsNumber(1), JsString("beta"), JsString("delta"), JsNumber(4), JsString("five"))).validate[List[Int]] mustEqual (
        JsError(Seq(
          JsPath(1) -> Seq(JsonValidationError("error.expected.jsnumber")),
          JsPath(2) -> Seq(JsonValidationError("error.expected.jsnumber")),
          JsPath(4) -> Seq(JsonValidationError("error.expected.jsnumber"))
        ))
      )

      JsArray(Stream(JsString("alpha"), JsNumber(5), JsBoolean(true))).validate[List[Int]] mustEqual (
        JsError(Seq(
          JsPath(0) -> Seq(JsonValidationError("error.expected.jsnumber")),
          JsPath(2) -> Seq(JsonValidationError("error.expected.jsnumber"))
        ))
      )
    }
```

I personally think this is not a problem, as `JsArray` constructor are
not documented as public APIs on the github page (though they seem to be exposed [here](https://www.playframework.com/documentation/2.5.x/ScalaJson#Using-class-construction)), and users seem to be pushed towards using
`Json.arr` and friends. Nonetheless, if we think this is problematic, we
could add an overloaded version of `JsArray.apply` to maintain source
compatibility. Unfortunately, binary compatibility is probably a lost cause
with this kind of diff.

Like https://github.com/playframework/play-json/pull/66, this is submitted without any prior discussion or bug reports. Nonetheless, It seems like it's the right thing to do, and it was pretty easy to make these changes to show off even if it doesn't end up landing. Let me know what you think!

## Background Context

## References

