### PR TITLE
Optimize object merging for common cases used in Json macros

### DIFF
--- a/benchmarks/build.sbt
+++ b/benchmarks/build.sbt
@@ -1,0 +1,9 @@
+
+import pl.project13.scala.sbt.JmhPlugin
+
+sourceDirectory in Jmh := (sourceDirectory in Test).value
+classDirectory in Jmh := (classDirectory in Test).value
+dependencyClasspath in Jmh := (dependencyClasspath in Test).value
+// rewire tasks, so that 'jmh:run' automatically invokes 'jmh:compile' (otherwise a clean 'jmh:run' would fail)
+compile in Jmh <<= (compile in Jmh) dependsOn (compile in Test)
+run in Jmh <<= (run in Jmh) dependsOn (Keys.compile in Jmh)

--- a/benchmarks/src/test/scala/play/api/libs/json/Employee.scala
+++ b/benchmarks/src/test/scala/play/api/libs/json/Employee.scala
@@ -1,0 +1,29 @@
+package play.api.libs.json
+
+case class Employee(
+  employeeNumber: Int,
+  firstName: String,
+  lastName: String,
+  city: String,
+  country: String,
+  tags: Seq[String]
+)
+
+object Employee {
+  implicit val employeeFormat: Format[Employee] = Json.format[Employee]
+
+  val manualWrites: Writes[Employee] = Writes { e =>
+    Json.obj(
+      "employeeNumber" -> e.employeeNumber,
+      "firstName" -> e.firstName,
+      "lastName" -> e.lastName,
+      "city" -> e.city,
+      "country" -> e.country,
+      "tags" -> JsArray(e.tags.map(JsString.apply))
+    )
+  }
+
+  val manualSeqWrites: Writes[Seq[Employee]] = Writes { seq =>
+    JsArray(seq.map(manualWrites.writes))
+  }
+}

--- a/benchmarks/src/test/scala/play/api/libs/json/JsonMacros_01_SerializeSimpleCaseClass.scala
+++ b/benchmarks/src/test/scala/play/api/libs/json/JsonMacros_01_SerializeSimpleCaseClass.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.json
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Benchmark)
+class JsonMacros_01_SerializeSimpleCaseClass {
+
+  var employee: Employee = _
+  var employeeJson: JsValue = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    employee = Employee(
+      42,
+      "Foo",
+      "Bar",
+      "New York",
+      "United States",
+      Seq("engineering", "new", "bar")
+    )
+  }
+
+  @TearDown(Level.Iteration)
+  def tearDown(): Unit = {
+    assert(employeeJson == Json.parse(
+      """ {
+        |   "employeeNumber": 42,
+        |   "firstName": "Foo",
+        |   "lastName": "Bar",
+        |   "city": "New York",
+        |   "country": "United States",
+        |   "tags": ["engineering", "new", "bar"]
+        | }
+      """.stripMargin))
+  }
+
+  @Benchmark
+  def toJson(): JsValue = {
+    employeeJson = Json.toJson(employee)
+    employeeJson
+  }
+
+  @Benchmark
+  def toJsonManualWrites(): JsValue = {
+    employeeJson = Json.toJson(employee)(Employee.manualWrites)
+    employeeJson
+  }
+
+}

--- a/benchmarks/src/test/scala/play/api/libs/json/JsonMacros_02_SerializeList.scala
+++ b/benchmarks/src/test/scala/play/api/libs/json/JsonMacros_02_SerializeList.scala
@@ -1,0 +1,41 @@
+package play.api.libs.json
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Benchmark)
+class JsonMacros_02_SerializeList {
+
+  var employees: Seq[Employee] = _
+  var employeesJson: JsValue = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    employees = (1 to 100) map { id =>
+      Employee(
+        id,
+        s"Foo$id",
+        s"Bar$id",
+        "New York",
+        "United States",
+        Seq("a", "b", "c")
+      )
+    }
+  }
+
+  @TearDown(Level.Iteration)
+  def tearDown(): Unit = {
+
+  }
+
+  @Benchmark
+  def toJson(): JsValue = {
+    employeesJson = Json.toJson(employees)
+    employeesJson
+  }
+
+  @Benchmark
+  def toJsonManualWrites(): JsValue = {
+    employeesJson = Json.toJson(employees)(Employee.manualSeqWrites)
+    employeesJson
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -160,6 +160,13 @@ lazy val `play-functional` = crossProject.crossType(CrossType.Pure)
 lazy val `play-functionalJVM` = `play-functional`.jvm
 lazy val `play-functionalJS` = `play-functional`.js
 
+import pl.project13.scala.sbt.JmhPlugin
+lazy val benchmarks = project
+  .in(file("benchmarks"))
+  .enablePlugins(JmhPlugin, PlayNoPublish)
+  .settings(commonSettings)
+  .dependsOn(`play-jsonJVM`)
+
 playBuildRepoName in ThisBuild := "play-json"
 
 releaseProcess := Seq[ReleaseStep](

--- a/play-json/shared/src/main/scala/JsValue.scala
+++ b/play-json/shared/src/main/scala/JsValue.scala
@@ -121,7 +121,7 @@ object JsArray extends scala.runtime.AbstractFunction1[IndexedSeq[JsValue], JsAr
  * Represent a Json object value.
  */
 case class JsObject(
-    private val underlying: Map[String, JsValue]
+    private[json] val underlying: Map[String, JsValue]
 ) extends JsValue {
 
   /**

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,8 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.3.5"))
 
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.24")
+
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.13")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")


### PR DESCRIPTION
The [functional combinators](https://www.playframework.com/documentation/2.6.x/ScalaJsonCombinators), which are also used by the JSON macros, suffer from some pretty serious performance issues because of the way they're constructed. For `Writes`, most of the time is spent constructing objects by merging `JsPath`s and merging in single-element objects, so I've optimized for those cases to get about a 5x speedup. I've also included some JMH benchmarks.