### PR TITLE
Add Tuple-`Reads`/`Writes` support, encoding them a `JsArray`s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,50 @@ lazy val `play-json` = crossProject.crossType(CrossType.Full)
       "org.typelevel" %% "macro-compat" % "1.1.1",
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-    )
+    ),
+    sourceGenerators in Compile += Def.task{
+      val dir = (sourceManaged in Compile).value
+
+      val file = dir / "upickle" / "Generated.scala"
+      val (writes, reads) = (1 to 22).map{ i =>
+        def commaSeparated(s: Int => String) = (1 to i).map(s).mkString(", ")
+        def newlineSeparated(s: Int => String) = (1 to i).map(s).mkString("\n")
+        val writerTypes = commaSeparated(j => s"T$j: Writes")
+        val readerTypes = commaSeparated(j => s"T$j: Reads")
+        val typeTuple = commaSeparated(j => s"T$j")
+        val written = commaSeparated(j => s"implicitly[Writes[T$j]].writes(x._$j)")
+        val readValues = commaSeparated(j => s"t$j")
+        val readGenerators = newlineSeparated(j => s"t$j <- implicitly[Reads[T$j]].reads(arr(${j-1}))")
+        (s"""
+          implicit def Tuple${i}W[$writerTypes]: Writes[Tuple${i}[$typeTuple]] = Writes[Tuple${i}[$typeTuple]](
+            x => JsArray(Array($written))
+          )
+          """,s"""
+          implicit def Tuple${i}R[$readerTypes]: Reads[Tuple${i}[$typeTuple]] = Reads[Tuple${i}[$typeTuple]]{
+            case JsArray(arr) if arr.size == $i =>
+              for{
+                $readGenerators
+              } yield Tuple$i($readValues)
+
+            case _ =>
+              JsError(Seq(JsPath() -> Seq(JsonValidationError("Expected array of $i elements"))))
+          }
+        """)
+      }.unzip
+
+      IO.write(file, s"""
+          package play.api.libs.json
+
+          trait GeneratedReads {
+            ${reads.mkString("\n")}
+          }
+
+          trait GeneratedWrites{
+            ${writes.mkString("\n")}
+          }
+        """)
+      Seq(file)
+    }.taskValue
   )
   .dependsOn(`play-functional`)
 

--- a/play-json/shared/src/main/scala/Reads.scala
+++ b/play-json/shared/src/main/scala/Reads.scala
@@ -71,7 +71,7 @@ trait Reads[A] { self =>
 /**
  * Default deserializer type classes.
  */
-object Reads extends ConstraintReads with PathReads with DefaultReads {
+object Reads extends ConstraintReads with PathReads with DefaultReads with GeneratedReads {
 
   val constraints: ConstraintReads = this
 

--- a/play-json/shared/src/main/scala/Writes.scala
+++ b/play-json/shared/src/main/scala/Writes.scala
@@ -87,7 +87,7 @@ object OWrites extends PathWrites with ConstraintWrites {
 /**
  * Default Serializers.
  */
-object Writes extends PathWrites with ConstraintWrites with DefaultWrites {
+object Writes extends PathWrites with ConstraintWrites with DefaultWrites with GeneratedWrites {
 
   val constraints: ConstraintWrites = this
   val path: PathWrites = this

--- a/play-json/shared/src/test/scala/TupleSpec.scala
+++ b/play-json/shared/src/test/scala/TupleSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.json
+
+import org.scalatest._
+
+class TupleSpec extends WordSpec with MustMatchers {
+  "Reading/Write tuples" should {
+    def check[T: Reads: Writes](value: T, expected: String) = {
+      Json.stringify(Json.toJson(value)) mustEqual expected
+      Json.fromJson(Json.parse(expected)).get mustEqual value
+    }
+    "work for small tuples" in {
+      check(Tuple1(1), "[1]")
+      check((1, 2, "lol"), """[1,2,"lol"]""")
+    }
+    "work for large tuples" in {
+      check(
+        (1, 2, "lol", "foo", "bar", "baz", true, Seq(1, 2)),
+        """[1,2,"lol","foo","bar","baz",true,[1,2]]"""
+      )
+    }
+    "work for nested tuples" in {
+      check(
+        (1, 2, ("lol", ("foo", "bar"))),
+        """[1,2,["lol",["foo","bar"]]]"""
+      )
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

-

## Purpose

We generate the readers/writes from `Tuple1` to `Tuple22` in `build.sbt`
to avoid copy-pasting them manually. Tests don't cover all 22 arities,
but just a small selection of arities that will likely catch any errors.

## Background Context

This helps bring play-json up to parity with uPickle, which also auto-generates 
its tuple picklers using basically identical code.
