### PR TITLE
Bumps Jackson version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val specsBuild = Seq(
   "specs2-core"
 ).map("org.specs2" %% _ % specsVersion)
 
-val jacksonVersion = "2.8.8"
+val jacksonVersion = "2.8.9"
 val jacksons = Seq(
   "com.fasterxml.jackson.core" % "jackson-core",
   "com.fasterxml.jackson.core" % "jackson-annotations",


### PR DESCRIPTION
Play core 2.6.0 uses Jackson 2.8.9 so using play core _and_ play-json tries to import both versions of jackson.

Should we remove the dependency of jackson in play-core so that play-core only depends on play-json?