### PR TITLE
Use Function1 instead of AbstractFunction1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,8 @@ lazy val `play-json` = crossProject.crossType(CrossType.Full)
   .settings(
     mimaBinaryIssueFilters ++= Seq(
       // AbstractFunction1 is in scala.runtime and isn't meant to be used by end users
-      ProblemFilters.exclude[MissingTypesProblem]("play.api.libs.json.JsArray$")
+      ProblemFilters.exclude[MissingTypesProblem]("play.api.libs.json.JsArray$"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.api.libs.json.JsObject$")
     ),
     libraryDependencies ++= jsonDependencies(scalaVersion.value) ++ Seq(
       "org.scalatest" %%% "scalatest" % "3.0.3" % Test,

--- a/play-json/shared/src/main/scala/JsValue.scala
+++ b/play-json/shared/src/main/scala/JsValue.scala
@@ -198,7 +198,7 @@ case class JsObject(
   override def hashCode: Int = fieldSet.hashCode()
 }
 
-object JsObject extends scala.runtime.AbstractFunction1[Seq[(String, JsValue)], JsObject] {
+object JsObject extends (Seq[(String, JsValue)] => JsObject) {
   /**
    * Construct a new JsObject, with the order of fields in the Seq.
    */


### PR DESCRIPTION
As indicated by the comment, AbstractFunction1 is in scala.runtime and isn't meant to be used by end users. I forgot to change this one from a previous PR. Should have done a search for AbstractFunction1.