### PR TITLE
[Failed test] jsonWithDefaults macro generated code fails with stackoverflow

### DIFF
--- a/play-json/shared/src/test/scala/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/MacroSpec.scala
@@ -266,6 +266,12 @@ class MacroSpec extends WordSpec with MustMatchers
       )
     }
 
+    "handle case class with default values, format defined in companion object" in {
+      val json = Json.obj("id" -> 15)
+      val expected = WithDefaultInCompanion(15, "a")
+      Json.fromJson[WithDefaultInCompanion](json).get mustEqual expected
+    }
+
     "handle case class with default values inner optional case class containing default values" when {
       implicit val cfg = JsonConfiguration(JsonNaming.Identity)
       implicit val withDefaultFormat = Json.using[Json.MacroOptions with Json.DefaultValues].format[WithDefault]
@@ -488,4 +494,9 @@ class MacroSpec extends WordSpec with MustMatchers
     seq: Seq[B],
     scores: Map[String, Float]
   )
+
+  case class WithDefaultInCompanion(id: Int, a: String = "a")
+  object WithDefaultInCompanion {
+    implicit val format: OFormat[WithDefaultInCompanion] = Json.using[Json.WithDefaultValues].format[WithDefaultInCompanion]
+  }
 }


### PR DESCRIPTION
Materializing the `Format[T]` (e.g. by calling `implicitly[Format[MyClass]]`) will cause a stack overflow error.

In this case the format is declared in the companion object, and it seems to be important that it's an inner class (in this case defined inside the test suite class).

Changing to `lazy val format = ...` fixes it
```
...
at play.api.libs.json.JsPath.formatWithDefault(JsPath.scala:401)
at play.api.libs.json.MacroSpec$WithDefaultInCompanion$.<init>(MacroSpec.scala:500)
at play.api.libs.json.MacroSpec.WithDefaultInCompanion$lzycompute$1(MacroSpec.scala:499)
at play.api.libs.json.MacroSpec.WithDefaultInCompanion(MacroSpec.scala:499)
at play.api.libs.json.MacroSpec$WithDefaultInCompanion$.$anonfun$format$1(MacroSpec.scala:500)
at play.api.libs.json.PathReads.withDefault(JsConstraints.scala:36)
at play.api.libs.json.PathReads.withDefault$(JsConstraints.scala:35)
at play.api.libs.json.Reads$.withDefault(Reads.scala:74)
at play.api.libs.json.PathFormat.withDefault(JsConstraints.scala:20)
at play.api.libs.json.PathFormat.withDefault$(JsConstraints.scala:19)
at play.api.libs.json.Format$.withDefault(Format.scala:52)
at play.api.libs.json.JsPath.formatWithDefault(JsPath.scala:401)
at play.api.libs.json.MacroSpec$WithDefaultInCompanion$.<init>(MacroSpec.scala:500)
at play.api.libs.json.MacroSpec.WithDefaultInCompanion$lzycompute$1(MacroSpec.scala:499)
at play.api.libs.json.MacroSpec.WithDefaultInCompanion(MacroSpec.scala:499)
at play.api.libs.json.MacroSpec$WithDefaultInCompanion$.$anonfun$format$1(MacroSpec.scala:500)
at play.api.libs.json.PathReads.withDefault(JsConstraints.scala:36)
at play.api.libs.json.PathReads.withDefault$(JsConstraints.scala:35)
at play.api.libs.json.Reads$.withDefault(Reads.scala:74)
at play.api.libs.json.PathFormat.withDefault(JsConstraints.scala:20)
at play.api.libs.json.PathFormat.withDefault$(JsConstraints.scala:19)
at play.api.libs.json.Format$.withDefault(Format.scala:52)
at play.api.libs.json.JsPath.formatWithDefault(JsPath.scala:401)
at play.api.libs.json.MacroSpec$WithDefaultInCompanion$.<init>(MacroSpec.scala:500)
at play.api.libs.json.MacroSpec.WithDefaultInCompanion$lzycompute$1(MacroSpec.scala:499)
at play.api.libs.json.MacroSpec.WithDefaultInCompanion(MacroSpec.scala:499)
at play.api.libs.json.MacroSpec$WithDefaultInCompanion$.$anonfun$format$1(MacroSpec.scala:500)
at play.api.libs.json.PathReads.withDefault(JsConstraints.scala:36)
at play.api.libs.json.PathReads.withDefault$(JsConstraints.scala:35)
at play.api.libs.json.Reads$.withDefault(Reads.scala:74)
at play.api.libs.json.PathFormat.withDefault(JsConstraints.scala:20)
at play.api.libs.json.PathFormat.withDefault$(JsConstraints.scala:19)
at play.api.libs.json.Format$.withDefault(Format.scala:52)
...
```