### PR TITLE
Force ScalaJS fullOpt on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
 jdk:
 - oraclejdk8
 script:
-- sbt ++$TRAVIS_SCALA_VERSION validateCode mimaReportBinaryIssues testOnly
+- sbt -DscalaJSStage=full ++$TRAVIS_SCALA_VERSION validateCode mimaReportBinaryIssues testOnly
 cache:
   directories:
   - "$HOME/.ivy2/cache"

--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,13 @@ def playJsonMimaSettings = mimaDefaultSettings ++ Seq(
   mimaPreviousArtifacts := previousVersions.value.map(organization.value %%% moduleName.value % _).toSet
 )
 
+// Workaround for https://github.com/scala-js/scala-js/issues/2378
+// Use "sbt -DscalaJSStage=full" in .travis.yml
+scalaJSStage in ThisBuild := (sys.props.get("scalaJSStage") match {
+  case Some("full") => FullOptStage
+  case _ => FastOptStage
+})
+
 lazy val commonSettings = SbtScalariform.scalariformSettings ++ Seq(
     scalaVersion := ScalaVersions.scala212,
     crossScalaVersions := Seq(ScalaVersions.scala210, ScalaVersions.scala211, ScalaVersions.scala212),


### PR DESCRIPTION
I think this fixes the build failures we've been seeing recently on scala 2.10/2.11.