### PR TITLE
Added strict properties feature

### DIFF
--- a/docs/manual/working/scalaGuide/main/json/ScalaJsonAutomated.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJsonAutomated.md
@@ -60,3 +60,9 @@ A strategy other than the default one can be used as following:
 To implement your own Naming Strategy you just need to implement the `JsonNaming` trait:
 
 @[auto-custom-naming-format](code/ScalaJsonAutomatedSpec.scala)
+
+## Failing on unknown properties
+
+The JSON macros support a `StrictProperties` option that allows you to fail when unknown properties are encountered. This can be enabled like so:
+
+@[strict-properties](code/ScalaJsonAutomatedSpec.scala)

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -185,5 +185,18 @@ class ScalaJsonAutomatedSpec extends Specification {
 
       residentFromJson.get must_=== sampleData
     }
+
+    "allow strict properties" in {
+      //#strict-properties
+      import play.api.libs.json._
+
+      implicit val residentReads: Reads[Resident] =
+        Json.using[Json.WithStrictProperties].reads[Resident]
+      //#strict-properties
+
+      sampleJson.as[Resident] must_== sampleData
+      Json.fromJson(sampleJson.as[JsObject] + ("other" -> JsString("none"))) must beAnInstanceOf[JsError]
+    }
+
   }
 }

--- a/play-json/shared/src/main/scala/Json.scala
+++ b/play-json/shared/src/main/scala/Json.scala
@@ -360,7 +360,7 @@ object Json extends JsonFacade {
      *   Json.using[Json.MacroOptions].writes[User]
      * }}}
      */
-    def writes[A]: OWrites[A] = macro JsMacroImpl.writesImpl[A, MacroOptions]
+    def writes[A]: OWrites[A] = macro JsMacroImpl.writesImpl[A, Opts]
 
     /**
      * Creates a `OFormat[T]` by resolving, at compile-time,
@@ -432,4 +432,19 @@ object Json extends JsonFacade {
    * }}}
    */
   type WithDefaultValues = MacroOptions with DefaultValues
+
+  /**
+   * Flag to indicate that the macros should generate reads
+   * that fail on unknown properties.
+   */
+  trait StrictProperties { _: MacroOptions => }
+
+  /**
+   * Alias for `MacroOptions with StrictProperties`
+   *
+   * {{{
+   * Json.using[WithStrictProperties]
+   * }}}
+   */
+  type WithStrictProperties = MacroOptions with StrictProperties
 }

--- a/play-json/shared/src/main/scala/Reads.scala
+++ b/play-json/shared/src/main/scala/Reads.scala
@@ -192,6 +192,22 @@ trait DefaultReads extends LowPriorityDefaultReads {
   }
 
   /**
+   * A reads that fails if any of the objects properties are not present in the passed in known properties list.
+   */
+  def failOnUnknownProperties(knownProperties: immutable.Seq[String]): Reads[JsObject] = Reads { jsValue =>
+    JsObjectReads.reads(jsValue).flatMap { jsObject =>
+      val unknown = jsObject.keys -- knownProperties
+      if (unknown.isEmpty) {
+        JsSuccess(jsObject)
+      } else {
+        JsError(unknown.map { prop =>
+          __ \ prop -> Seq(JsonValidationError("error.unexpected.property"))
+        }.toSeq)
+      }
+    }
+  }
+
+  /**
    * Deserializer for Int types.
    */
   implicit object IntReads extends Reads[Int] {


### PR DESCRIPTION
This adds a new feature flag to the macro opts that allows enabling strict properties - that is, the produced JSON reads/format will fail if any unknown properties are encountered. This is useful particularly in testing if you have a JSON structure pulled from a system that you're consuming data from, and you want to verify that your case classes correctly match it, and haven't misnamed any optional properties.