### PR TITLE
Improved configuration passing

### DIFF
--- a/play-json/shared/src/main/scala/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/JsonConfiguration.scala
@@ -22,16 +22,19 @@ object JsonConfiguration {
     type Opts = O
   }
 
+  // These methods exist for binary compatibility, since Scala protected methods are public from a binary perspective.
+  protected def apply(naming: JsonNaming): JsonConfiguration.Aux[Json.MacroOptions] = new Impl(naming)
+  protected def default: JsonConfiguration.Aux[Json.MacroOptions] = apply()
+
   /**
-   * @tparam O the options for the JSON macros
    * @param naming the naming strategy
    */
-  def apply[O <: Json.MacroOptions](
+  def apply[Opts <: Json.MacroOptions: Json.MacroOptions.Default](
     naming: JsonNaming = JsonNaming.Identity
-  ): JsonConfiguration.Aux[O] = new Impl(naming)
+  ): JsonConfiguration.Aux[Opts] = new Impl(naming)
 
   /** Default configuration instance */
-  implicit def default[Opts <: Json.MacroOptions] = apply[Opts]()
+  implicit def default[Opts <: Json.MacroOptions: Json.MacroOptions.Default]: JsonConfiguration.Aux[Opts] = apply()
 }
 
 /**

--- a/play-json/shared/src/test/scala/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/JsonExtensionSpec.scala
@@ -91,6 +91,8 @@ object CustomApply {
 case class WithDefault1(a: String = "a", b: Option[String] = Some("b"))
 case class WithDefault2(a: String = "a", bar: Option[WithDefault1] = Some(WithDefault1()))
 
+case class WithDefaultSnake(firstProp: String, defaultProp: String = "the default")
+
 class JsonExtensionSpec extends WordSpec with MustMatchers {
   "JsonExtension" should {
     "create a reads[User]" in {
@@ -712,6 +714,21 @@ class JsonExtensionSpec extends WordSpec with MustMatchers {
       "by functional formats" in validateReads(functionalFormat)
       "by reads macro" in validateReads(macroReads)
       "by format macro" in validateReads(macroFormat)
+    }
+
+    "configuration methods" should {
+      val json = Json.obj("first_prop" -> "the first")
+      val data = WithDefaultSnake("the first")
+
+      "allow supplying configuration via implicit config" in {
+        implicit val config = JsonConfiguration[Json.WithDefaultValues](naming = SnakeCase)
+        json.as(Json.reads[WithDefaultSnake]) mustEqual data
+      }
+
+      "allow supplying configuration via WithOptions" in {
+        val config = JsonConfiguration[Json.WithDefaultValues](naming = SnakeCase)
+        json.as(Json.configured(config).reads[WithDefaultSnake]) mustEqual data
+      }
     }
   }
 }


### PR DESCRIPTION
The current implementation of passing configuration and macro options had a major problem. You could only pass a naming strategy by making an implicit JsonConfiguration variable available, while you could only pass a macro option using Json.using or Json.configured. If you used the wrong one for the wrong approach, then it didn't work.  So something like this:

```scala
implicit val config = JsonConfiguration[WithDefaultValues](SnakeCase)
```

Would use snake case, but not default values, while:

```scala
Json.configured(JsonConfiguration[WithDefaultValues](SnakeCase))
```

Would turn on default values, but not use snake case. Very confusing for end users.

This fixes all that, now either method can be used to pass either configuration or macro options.