### PR TITLE
Check in macro that some subclass are found for a sealed trait

### DIFF
--- a/play-json/shared/src/main/scala/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/JsMacroImpl.scala
@@ -487,6 +487,10 @@ import scala.reflect.macros.blackbox
     val readsType = c.typeOf[Reads[_]]
 
     def macroSealedFamilyImpl(subTypes: List[Type]): c.Expr[M[A]] = {
+      if (subTypes.isEmpty) {
+        c.abort(c.enclosingPosition, s"Sealed trait ${atpe} is not supported: no known subclasses")
+      }
+
       val typeNaming = (_: Type).typeSymbol.fullName
 
       def readLambda: Tree = {

--- a/play-json/shared/src/test/scala/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/MacroSpec.scala
@@ -110,6 +110,10 @@ class MacroSpec extends WordSpec with MustMatchers
       val simple = Simple("foo")
       val optional = Optional(None)
 
+      shapeless.test.illTyped("Json.reads[EmptyFamily]")
+      shapeless.test.illTyped("Json.writes[EmptyFamily]")
+      shapeless.test.illTyped("Json.format[EmptyFamily]")
+
       "using the _value syntax" in {
         val jsSimple = Json.obj(
           "_type" -> "play.api.libs.json.MacroSpec.Simple",
@@ -523,6 +527,8 @@ class MacroSpec extends WordSpec with MustMatchers
   case class Simple(bar: String) extends Family
   case class Lorem[T](ipsum: T, age: Int) extends Family
   case class Optional(prop: Option[String]) extends Family
+
+  sealed trait EmptyFamily
 
   case class Foo(id: Long, value: Option[Either[String, Foo]])
   case class Interval[T](base: T, other: Option[T])


### PR DESCRIPTION
Prevent generating useless handler for an empty sealed family.

```scala
scala> import play.api.libs.json._
import play.api.libs.json._

scala> sealed trait Foo {}
defined trait Foo

scala> Json.reads[Foo]
<console>:16: error: Sealed trait Foo is not supported: no known subclasses
       Json.reads[Foo]
```