### PR TITLE
Jsobject lookup

### DIFF
--- a/play-json/shared/src/main/scala/JsLookup.scala
+++ b/play-json/shared/src/main/scala/JsLookup.scala
@@ -63,7 +63,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    */
   def apply(fieldName: String): JsValue = result match {
     case JsDefined(x) => x match {
-      case arr: JsObject => arr.value.lift(fieldName) match {
+      case arr: JsObject => arr.underlying.get(fieldName) match {
         case Some(x) => x
         case None => throw new NoSuchElementException(String.valueOf(fieldName))
       }
@@ -95,7 +95,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    */
   def \(fieldName: String): JsLookupResult = result match {
     case JsDefined(obj @ JsObject(_)) =>
-      obj.value.get(fieldName).map(JsDefined.apply)
+      obj.underlying.get(fieldName).map(JsDefined.apply)
         .getOrElse(JsUndefined(s"'$fieldName' is undefined on object: $obj"))
     case JsDefined(o) =>
       JsUndefined(s"$o is not an object")
@@ -109,7 +109,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    */
   def \\(fieldName: String): Seq[JsValue] = result match {
     case JsDefined(obj: JsObject) =>
-      obj.value.foldLeft(Seq[JsValue]())((o, pair) => pair match {
+      obj.underlying.foldLeft(Seq[JsValue]())((o, pair) => pair match {
         case (key, value) if key == fieldName => o ++ (value +: (value \\ fieldName))
         case (_, value) => o ++ (value \\ fieldName)
       })


### PR DESCRIPTION
## Purpose

Limit the amount of memory allocation during deserialization of JSON object to improve performance. This change doesn't affect the idiomaticity of the code.

## Background Context

While doing some benchmarking on our code, I found out that we were spending a non-negligible amount of time building `Map` when deserialization of JSON. By investigating deeper, I found out that play-json was doing multiple copy of the same `Map`.

For example, the following code with the current implementation, will create a `mutable.ListBuffer` convert it to `mutable.LinkedHashMap` and convert this `mutable.LinkedHashMap` to a `immutable.HashMap` before doing a lookup of the key "d".

```scala
(Json.parse("""{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}""") \ "d").as[Int]
```

We the proposed change, this code would create directly a `mutable.LinkedHashMap` and to the lookup directly on this `mutable.LinkedHashMap`.

Alternatively, we could build directly a `immutable.ListMap` which would still preserve the ordering of the keys and is likely to be faster for small JsObject (which is probably the majority of the JsObject created), but would have big penalty for big one.
