### PR TITLE
update jackson to 2.9.1 version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val specsBuild = Seq(
   "specs2-core"
 ).map("org.specs2" %% _ % specsVersion)
 
-val jacksonVersion = "2.8.9"
+val jacksonVersion = "2.9.1"
 val jacksons = Seq(
   "com.fasterxml.jackson.core" % "jackson-core",
   "com.fasterxml.jackson.core" % "jackson-annotations",


### PR DESCRIPTION
New version of Jackson (2.9.1) [released](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.1)
 build.sbt updated