### PR TITLE
Strict implementation for Reads when default value is provided

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
@@ -34,7 +34,7 @@ trait PathReads {
   def at[A](path: JsPath)(implicit reads: Reads[A]): Reads[A] = Reads[A](js => path.asSingleJsResult(js).flatMap(reads.reads(_).repath(path)))
 
   def withDefault[A](path: JsPath, defaultValue: => A)(implicit reads: Reads[A]): Reads[A] =
-    at[A](path) orElse Reads.pure(defaultValue)
+    nullable[A](path).map(_ getOrElse defaultValue)
 
   /**
    * Reads a Option[T] search optional or nullable field at JsPath (field not found or null is None

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
@@ -282,9 +282,8 @@ case class JsPath(path: List[PathNode] = List()) {
   def read[T](implicit r: Reads[T]): Reads[T] = Reads.at[T](this)(r)
 
   /** Reads a T at JsPath */
-  def readWithDefault[T](defaultValue: => T)(implicit r: Reads[T]): Reads[T] = {
-    read[T] orElse Reads.pure(defaultValue)
-  }
+  def readWithDefault[T](defaultValue: => T)(implicit r: Reads[T]): Reads[T] =
+    Reads.withDefault[T](this, defaultValue)
 
   /**
    * Reads a Option[T] search optional or nullable field at JsPath (field not found or null is None

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -705,9 +705,11 @@ class JsonExtensionSpec extends WordSpec with MustMatchers {
 
       def validateReads(fooReads: Reads[WithDefault2]) = {
         fooReads.reads(Json.obj()) mustEqual JsSuccess(WithDefault2())
+        fooReads.reads(Json.obj("a" -> JsNull)) mustEqual JsSuccess(WithDefault2())
         fooReads.reads(Json.obj("bar" -> JsNull)) mustEqual JsSuccess(WithDefault2(bar = None))
         fooReads.reads(Json.obj("a" -> "z")) mustEqual JsSuccess(WithDefault2(a = "z"))
         fooReads.reads(Json.obj("a" -> "z", "bar" -> Json.obj("b" -> "z"))) mustEqual JsSuccess(WithDefault2(a = "z", bar = Some(WithDefault1(b = Some("z")))))
+        fooReads.reads(Json.obj("a" -> 1)) mustEqual JsError(List((JsPath \ "a") -> List(JsonValidationError("error.expected.jsstring"))))
       }
 
       "by functional reads" in validateReads(functionalReads)


### PR DESCRIPTION
- uses default value only if json node is empty or missing
- default value will not be used in case of failure
