### PR TITLE
Adding PascalCase to JsonConfiguration default implementation.

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -71,6 +71,7 @@ object JsonNaming {
       val result = new StringBuilder(length * 2)
       var resultLength = 0
       var wasPrevTranslated = false
+
       for (i <- 0 until length) {
         var c = property.charAt(i)
         if (i > 0 || i != '_') {
@@ -103,10 +104,11 @@ object JsonNaming {
    */
   object PascalCase extends JsonNaming {
     def apply(property: String): String =
-      if (property.length > 0)
-        property.updated(0, Character.toUpperCase(property.charAt(0)))
-      else
+      if (property.length > 0) {
+        property.updated(0, Character.toUpperCase(property charAt 0))
+      } else {
         property
+      }
 
     override val toString = "PascalCase"
   }

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -97,6 +97,20 @@ object JsonNaming {
     override val toString = "SnakeCase"
   }
 
+  /**
+   * For each class property, use the pascal case equivalent
+   * to name its column (e.g. fooBar -> FooBar).
+   */
+  object PascalCase extends JsonNaming {
+    def apply(property: String): String =
+      if (property.length > 0)
+        property.updated(0, Character.toUpperCase(property.charAt(0)))
+      else
+        property
+
+    override val toString = "PascalCase"
+  }
+
   /** Naming using a custom transformation function. */
   def apply(transformation: String => String): JsonNaming = new JsonNaming {
     def apply(property: String): String = transformation(property)

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -19,6 +19,7 @@ object UserProfile {
   def obj1 = UserProfile("Christian", "Schmitt", None, "Kenzingen")
   def json1 = Json.obj("first_name" -> "Christian", "last_name" -> "Schmitt", "city" -> "Kenzingen")
   def json2 = Json.obj("lightbend_firstName" -> "Christian", "lightbend_lastName" -> "Schmitt", "lightbend_city" -> "Kenzingen")
+  def json3 = Json.obj("FirstName" -> "Christian", "LastName" -> "Schmitt", "City" -> "Kenzingen")
 }
 case class UserProfileHolder(holder: String, profile: UserProfile)
 case class Cat(name: String)
@@ -603,6 +604,34 @@ class JsonExtensionSpec extends WordSpec with MustMatchers {
 
       Json.fromJson(UserProfile.json1) mustEqual (JsSuccess(UserProfile.obj1))
       Json.toJson(UserProfile.obj1) mustEqual (UserProfile.json1)
+    }
+
+    "create a writes[UserProfile] with PascalCase" in {
+      import play.api.libs.json.Json
+
+      implicit val jsonConfiguration = JsonConfiguration(naming = JsonNaming.PascalCase)
+      implicit val writes = Json.writes[UserProfile]
+
+      Json.toJson(UserProfile.obj1) mustEqual (UserProfile.json3)
+    }
+
+    "create a reads[UserProfile] with PascalCase" in {
+      import play.api.libs.json.Json
+
+      implicit val jsonConfiguration = JsonConfiguration(naming = JsonNaming.PascalCase)
+      implicit val reads = Json.reads[UserProfile]
+
+      Json.fromJson(UserProfile.json3) mustEqual (JsSuccess(UserProfile.obj1))
+    }
+
+    "create a format[UserProfile] with PascalCase" in {
+      import play.api.libs.json.Json
+
+      implicit val jsonConfiguration = JsonConfiguration(naming = JsonNaming.PascalCase)
+      implicit val format = Json.format[UserProfile]
+
+      Json.fromJson(UserProfile.json3) mustEqual (JsSuccess(UserProfile.obj1))
+      Json.toJson(UserProfile.obj1) mustEqual (UserProfile.json3)
     }
 
     "create a writes[UserProfile] with CustomNaming" in {


### PR DESCRIPTION
## Purpose

Adding PascalCase to JsonConfiguration default implementation.

## Background Context

Found it useful when reading JSON from AWS http sns-webhook since it is using pascal case.
