### PR TITLE
inline Reads.of, Format.of (ala implicitly)

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
@@ -5,7 +5,7 @@
 package play.api.libs.json
 
 trait ConstraintFormat {
-  def of[A](implicit fmt: Format[A]): Format[A] = fmt
+  @inline def of[A](implicit fmt: Format[A]): Format[A] = fmt
 
   def optionWithNull[A](implicit fmt: Format[A]): Format[Option[A]] = Format[Option[A]](Reads.optionWithNull(fmt), Writes.optionWithNull(fmt))
 }
@@ -95,7 +95,7 @@ trait PathReads {
 
 trait ConstraintReads {
   /** The simpler of all Reads that just finds an implicit Reads[A] of the expected type */
-  def of[A](implicit r: Reads[A]) = r
+  @inline def of[A](implicit r: Reads[A]) = r
 
   /** very simple optional field Reads that maps "null" to None */
   def optionWithNull[T](implicit rds: Reads[T]): Reads[Option[T]] = Reads(js => js match {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] ~~Have you updated the documentation?~~ N/A
* [ ] ~~Have you added tests for any changed functionality?~~ N/A

## Fixes

Fixes #xxxx

## Purpose

Mimic [`implicitly`](https://github.com/scala/scala/blob/07d61ecf134dbba143531f5a1bd3c1289c437296/src/library/scala/Predef.scala#L187), in `@inline`ing, the result of `Reads.of` and `Format.of`.

## Background Context

See above.

## References

N/A