### PR TITLE
Configure macro to allow it to output null in json during writes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,9 @@
 
 import interplay.ScalaVersions
 import ReleaseTransformations._
-
 import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import com.typesafe.tools.mima.plugin.MimaKeys.{
-  mimaBinaryIssueFilters, mimaPreviousArtifacts
-}
+import com.typesafe.tools.mima.plugin.MimaKeys.{mimaBinaryIssueFilters, mimaPreviousArtifacts}
 
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 
@@ -123,7 +120,8 @@ lazy val `play-json` = crossProject.crossType(CrossType.Full)
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultWrites.BigIntWrites"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultWrites.BigIntegerWrites"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultReads.BigIntReads"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultReads.BigIntegerReads")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultReads.BigIntegerReads"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.optionHandlers")
     ),
     libraryDependencies ++= jsonDependencies(scalaVersion.value) ++ Seq(
       "org.scalatest" %%% "scalatest" % "3.0.4" % Test,

--- a/docs/manual/working/scalaGuide/main/json/ScalaJsonAutomated.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJsonAutomated.md
@@ -60,3 +60,10 @@ A strategy other than the default one can be used as following:
 To implement your own Naming Strategy you just need to implement the `JsonNaming` trait:
 
 @[auto-custom-naming-format](code/ScalaJsonAutomatedSpec.scala)
+
+
+## Customize the macro to output null
+
+The macro can be configured to output `null` values in the Json instead of removing the empty fields:
+
+@[auto-writes-null](code/ScalaJsonAutomatedSpec.scala)

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package scalaguide.json

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -42,6 +42,14 @@ class ScalaJsonAutomatedSpec extends Specification {
   )
   val sampleData2 = PlayUser("Schmitt", "Christian", 26)
 
+  val sampleJson4 = Json.parse(
+    """{
+      "name": "Fiver",
+      "age": 4,
+      "role": null
+    }"""
+  )
+
   "Scala JSON automated" should {
     "produce a working Reads" in {
 
@@ -185,6 +193,20 @@ class ScalaJsonAutomatedSpec extends Specification {
       //#auto-JSON-to-case-class
 
       residentFromJson.get must_=== sampleData
+    }
+
+    "produce a json object with nulls" in {
+      //#auto-writes-null
+      import play.api.libs.json._
+
+      implicit val config = JsonConfiguration(optionHandlers = OptionHandlers.WritesNull)
+      implicit val residentWrites = Json.writes[Resident]
+      //#auto-writes-null
+
+      val resident = Resident(name = "Fiver", age = 4, role = None)
+
+      Json.toJson(resident) must_=== sampleJson4
+
     }
   }
 }

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonCombinatorsSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonCombinatorsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package scalaguide.json

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package scalaguide.json

--- a/play-functional/src/main/scala/play/api/libs/functional/Alternative.scala
+++ b/play-functional/src/main/scala/play/api/libs/functional/Alternative.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.functional

--- a/play-functional/src/main/scala/play/api/libs/functional/Applicative.scala
+++ b/play-functional/src/main/scala/play/api/libs/functional/Applicative.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.functional

--- a/play-functional/src/main/scala/play/api/libs/functional/Functors.scala
+++ b/play-functional/src/main/scala/play/api/libs/functional/Functors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.functional

--- a/play-functional/src/main/scala/play/api/libs/functional/Monoid.scala
+++ b/play-functional/src/main/scala/play/api/libs/functional/Monoid.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.functional

--- a/play-functional/src/main/scala/play/api/libs/functional/Products.scala
+++ b/play-functional/src/main/scala/play/api/libs/functional/Products.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.functional

--- a/play-functional/src/main/scala/play/api/libs/functional/syntax/package.scala
+++ b/play-functional/src/main/scala/play/api/libs/functional/syntax/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.functional.syntax

--- a/play-json-joda/src/main/scala/play/api/libs/json/JodaReads.scala
+++ b/play-json-joda/src/main/scala/play/api/libs/json/JodaReads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json-joda/src/main/scala/play/api/libs/json/JodaWrites.scala
+++ b/play-json-joda/src/main/scala/play/api/libs/json/JodaWrites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json-joda/src/test/scala/play/api/libs/json/JsonJodaValidSpec.scala
+++ b/play-json-joda/src/test/scala/play/api/libs/json/JsonJodaValidSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/js/src/main/scala/EnvReads.scala
+++ b/play-json/js/src/main/scala/EnvReads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/js/src/main/scala/EnvWrites.scala
+++ b/play-json/js/src/main/scala/EnvWrites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/js/src/main/scala/StaticBinding.scala
+++ b/play-json/js/src/main/scala/StaticBinding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/js/src/test/scala/JsonSpec.scala
+++ b/play-json/js/src/test/scala/JsonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/jvm/src/main/scala/play/api/libs/json/StaticBinding.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/StaticBinding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json.jackson

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonPerformanceTest.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonPerformanceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/jvm/src/test/scala/play/api/libs/json/LocaleFixtures.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/LocaleFixtures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/jvm/src/test/scala/play/api/libs/json/ReadsSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/ReadsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/jvm/src/test/scala/play/api/libs/json/WritesSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/WritesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/Format.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Format.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -679,8 +679,8 @@ import scala.reflect.macros.blackbox
               q"$jspathTree.$c($v)($impl)"
 
             case (true, _) =>
-              val c = TermName(s"${methodName}Nullable")
-              q"$jspathTree.$c($impl)"
+              val c = TermName(s"${methodName}Handler")
+              q"$config.optionHandlers.$c($jspathTree)($impl)"
 
             case (false, Some(v)) =>
               val c = TermName(s"${methodName}WithDefault")

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
@@ -357,6 +357,13 @@ case class JsPath(path: List[PathNode] = List()) {
   def writeNullable[T](implicit w: Writes[T]): OWrites[Option[T]] = Writes.nullable[T](this)(w)
 
   /**
+   * Writes a Option[T] at given JsPath
+   * If None => writes 'null'
+   * else => writes the field using implicit Writes[T]
+   */
+  def writeOptionWithNull[T](implicit w: Writes[T]): OWrites[Option[T]] = Writes.at[Option[T]](this)(Writes.optionWithNull[T](w))
+
+  /**
    * Writes a T at JsPath using the explicit Writes[T] passed by name which is useful in case of
    * recursive case classes for ex
    *

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsReadable.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsReadable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/Json.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Json.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -131,7 +131,9 @@ object JsonNaming {
 trait OptionHandlers {
   def readHandler[T](jsPath: JsPath)(implicit r: Reads[T]): Reads[Option[T]]
   def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]]
-  def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]]
+  final def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]] = {
+    OFormat(readHandler(jsPath), writeHandler(jsPath))
+  }
 }
 
 /** OptionHandlers companion */
@@ -139,12 +141,11 @@ object OptionHandlers {
 
   /**
    * Default Option Handlers
-   * Uses readNullable and writesNullable under the hood
+   * Uses readNullable and writesNullable
    */
   object Default extends OptionHandlers {
     def readHandler[T](jsPath: JsPath)(implicit r: Reads[T]): Reads[Option[T]] = jsPath.readNullable
     def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeNullable
-    def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]] = jsPath.formatNullable
   }
 
   /**
@@ -154,8 +155,5 @@ object OptionHandlers {
   object WritesNull extends OptionHandlers {
     def readHandler[T](jsPath: JsPath)(implicit reads: Reads[T]): Reads[Option[T]] = jsPath.readNullable
     def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeOptionWithNull
-    def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]] = {
-      OFormat(jsPath.readNullable, jsPath.writeOptionWithNull)
-    }
   }
 }

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -13,7 +13,7 @@ sealed trait JsonConfiguration {
   def naming: JsonNaming
 
   /** How options are handled by the macro */
-  def optionHandlers: OptionHandlers = OptionHandlers.Default
+  def optionHandlers: OptionHandlers
 }
 
 object JsonConfiguration {
@@ -21,7 +21,7 @@ object JsonConfiguration {
 
   private final class Impl[O <: Json.MacroOptions](
     val naming: JsonNaming = JsonNaming.Identity,
-    override val optionHandlers: OptionHandlers = OptionHandlers.Default
+    val optionHandlers: OptionHandlers = OptionHandlers.Default
   ) extends JsonConfiguration {
     type Opts = O
 

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -142,9 +142,9 @@ object OptionHandlers {
    * Uses readNullable and writesNullable under the hood
    */
   object Default extends OptionHandlers {
-    override def readHandler[T](jsPath: JsPath)(implicit r: Reads[T]): Reads[Option[T]] = jsPath.readNullable
-    override def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeNullable
-    override def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]] = jsPath.formatNullable
+    def readHandler[T](jsPath: JsPath)(implicit r: Reads[T]): Reads[Option[T]] = jsPath.readNullable
+    def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeNullable
+    def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]] = jsPath.formatNullable
   }
 
   /**
@@ -152,9 +152,9 @@ object OptionHandlers {
    * Uses readNullable and writeOptionWithNull
    */
   object WritesNull extends OptionHandlers {
-    override def readHandler[T](jsPath: JsPath)(implicit reads: Reads[T]): Reads[Option[T]] = jsPath.readNullable
-    override def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeOptionWithNull
-    override def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]] = {
+    def readHandler[T](jsPath: JsPath)(implicit reads: Reads[T]): Reads[Option[T]] = jsPath.readNullable
+    def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeOptionWithNull
+    def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]] = {
       OFormat(jsPath.readNullable, jsPath.writeOptionWithNull)
     }
   }

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonValidationError.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonValidationError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/LazyHelper.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/LazyHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json.util

--- a/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/main/scala/play/api/libs/json/package.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsObjectSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsObjectSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsPathSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsPathSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsResultSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsResultSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -94,6 +94,8 @@ case class WithDefault2(a: String = "a", bar: Option[WithDefault1] = Some(WithDe
 
 case class WithDefaultSnake(firstProp: String, defaultProp: String = "the default")
 
+case class Optional(props: Option[String])
+
 class JsonExtensionSpec extends WordSpec with MustMatchers {
   "JsonExtension" should {
     "create a reads[User]" in {
@@ -760,6 +762,22 @@ class JsonExtensionSpec extends WordSpec with MustMatchers {
         val config = JsonConfiguration[Json.WithDefaultValues](naming = SnakeCase)
         json.as(Json.configured(config).reads[WithDefaultSnake]) mustEqual data
       }
+    }
+
+    "create a Writes[Optional] with optionHandlers=WritesNull" in {
+      implicit val jsonConfiguration = JsonConfiguration(optionHandlers = OptionHandlers.WritesNull)
+      val writer = Json.writes[Optional]
+      writer.writes(Optional(None)) mustEqual Json.obj("props" -> JsNull)
+    }
+
+    "create a Format[Optional] with optionHandlers=WritesNull" in {
+      implicit val jsonConfiguration = JsonConfiguration(optionHandlers = OptionHandlers.WritesNull)
+      val formatter = Json.format[Optional]
+      formatter.writes(Optional(None)) mustEqual Json.obj("props" -> JsNull)
+
+      formatter.reads(Json.obj()) mustEqual JsSuccess(Optional(None))
+      formatter.reads(Json.obj("props" -> JsNull)) mustEqual JsSuccess(Optional(None))
+      formatter.reads(Json.obj("props" -> Some("foo"))) mustEqual JsSuccess(Optional(Some("foo")))
     }
   }
 }

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonRichSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonRichSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonSharedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonTransSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonTransSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonValidSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonValidSharedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/ReadsSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/ReadsSharedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/TupleSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/TupleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json

--- a/play-json/shared/src/test/scala/play/api/libs/json/WritesSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/WritesSharedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.json


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

Add configuration to the Json macro to support cases like [this](https://stackoverflow.com/questions/34317253/explicitly-output-json-null-in-case-of-missing-optional-value)

## Background Context

I first tried to add a simple Boolean but the behaviour was not really clear in the case of `Json.format`. This approach with `OptionHandlers` makes it clearer what is used and it can be extended by a user.
