### PR TITLE
Fix #93: support object in macro

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -783,7 +783,7 @@ import scala.reflect.macros.blackbox
             case _ => $json.JsError("error.expected.jsobject")
           }
          """
-      def writer = q"$json.OWrites[$atpe]{_ => $json.Json.obj() }"
+      def writer = q"$json.OWrites[$atpe]{_ => $json.JsObject.empty }"
 
       val tree = methodName match {
         case "read" => reader
@@ -800,8 +800,8 @@ import scala.reflect.macros.blackbox
       case Some(subTypes) => macroSealedFamilyImpl(subTypes)
       case _ =>
         atpe match {
-          case TypeRef(_, _, args) => macroCaseImpl(args)
           case _: SingletonType => caseObjectImpl
+          case TypeRef(_, _, args) => macroCaseImpl(args)
           case _ =>
             c.abort(
               c.enclosingPosition,

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -609,15 +609,7 @@ import scala.reflect.macros.blackbox
       c.Expr[M[A]](tree)
     }
 
-    def macroCaseImpl: c.Expr[M[A]] = {
-      val tpeArgs: List[Type] = atpe match {
-        case TypeRef(_, _, args) => args
-
-        case t => c.abort(
-          c.enclosingPosition,
-          s"Type ${t.typeSymbol.fullName} is not a valid case class"
-        )
-      }
+    def macroCaseImpl(tpeArgs: List[Type]): c.Expr[M[A]] = {
       val utility = new CaseClass[A](tpeArgs)
       val (companioned, isCase) = utility.validCaseClass
 
@@ -783,11 +775,39 @@ import scala.reflect.macros.blackbox
       c.Expr[M[A]](finalTree)
     }
 
+    def caseObjectImpl: c.Expr[M[A]] = {
+      def reader =
+        q"""
+          $json.Reads[${atpe}] {
+            case obj @ $json.JsObject(_) => $json.JsSuccess(${atpe.termSymbol})
+            case _ => $json.JsError("error.expected.jsobject")
+          }
+         """
+      def writer = q"$json.OWrites[$atpe]{_ => $json.Json.obj() }"
+
+      val tree = methodName match {
+        case "read" => reader
+        case "write" => writer
+        case _ => q"""$json.OFormat[$atpe]($reader, $writer)"""
+      }
+      debug(showCode(tree))
+      c.Expr[M[A]](tree)
+    }
+
     // ---
 
     directKnownSubclasses match {
       case Some(subTypes) => macroSealedFamilyImpl(subTypes)
-      case _ => macroCaseImpl
+      case _ =>
+        atpe match {
+          case TypeRef(_, _, args) => macroCaseImpl(args)
+          case _: SingletonType => caseObjectImpl
+          case _ =>
+            c.abort(
+              c.enclosingPosition,
+              s"Type ${atpe.typeSymbol.fullName} is not a valid case class or an object"
+            )
+        }
     }
   }
 

--- a/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
@@ -523,6 +523,19 @@ class MacroSpec extends WordSpec with MustMatchers
       jsOptional.validate(Json.reads[Optional]).
         get mustEqual (optional)
     }
+
+    "handle case objects as empty JsObject" in {
+      case object Obj
+      val writer = Json.writes[Obj.type]
+      val reader = Json.reads[Obj.type]
+      val formatter = Json.format[Obj.type]
+
+      val jsObj = Json.obj()
+      writer.writes(Obj) mustEqual jsObj
+      reader.reads(jsObj) mustEqual JsSuccess(Obj)
+      formatter.writes(Obj) mustEqual jsObj
+      formatter.reads(jsObj) mustEqual JsSuccess(Obj)
+    }
   }
 
   // ---


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #93 

Scala `object`s (and `case object`s)  are serialized as empty Json objects.

I didn't make the distinction between `object` and `case object` as it seemed unecessary
