### PR TITLE
Customizable type discriminators for sealed case class family macro

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,8 @@ lazy val `play-json` = crossProject.crossType(CrossType.Full)
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultReads.BigIntReads"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultReads.BigIntegerReads"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.optionHandlers"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.discriminator")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.discriminator"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.classNaming")
     ),
     libraryDependencies ++= jsonDependencies(scalaVersion.value) ++ Seq(
       "org.scalatest" %%% "scalatest" % "3.0.5-M1" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,8 @@ lazy val `play-json` = crossProject.crossType(CrossType.Full)
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultWrites.BigIntegerWrites"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultReads.BigIntReads"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultReads.BigIntegerReads"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.optionHandlers")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.optionHandlers"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.discriminator")
     ),
     libraryDependencies ++= jsonDependencies(scalaVersion.value) ++ Seq(
       "org.scalatest" %%% "scalatest" % "3.0.5-M1" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,7 @@ lazy val `play-json` = crossProject.crossType(CrossType.Full)
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.DefaultReads.BigIntegerReads"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.optionHandlers"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.discriminator"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.classNaming")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsonConfiguration.typeNaming")
     ),
     libraryDependencies ++= jsonDependencies(scalaVersion.value) ++ Seq(
       "org.scalatest" %%% "scalatest" % "3.0.5-M1" % Test,

--- a/docs/manual/working/scalaGuide/main/json/ScalaJsonAutomated.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJsonAutomated.md
@@ -67,6 +67,14 @@ A strategy other than the default one can be used as following:
 @[auto-naming-writes](code/ScalaJsonAutomatedSpec.scala)
 @[auto-naming-format](code/ScalaJsonAutomatedSpec.scala)
 
+The trait representation can also be configured, with a custom name for the discriminator field or the way the names of the sub-types are encoded as value for this field:
+
+@[trait-custom-representation](code/ScalaJsonAutomatedSpec.scala)
+
+To do so, the settings `discriminator` and `typeNaming` can be defined in the resolved `JsonConfiguration`:
+
+@[auto-JSON-custom-trait](code/ScalaJsonAutomatedSpec.scala)
+
 ### Implementing your own Naming Strategy
 
 To implement your own Naming Strategy you just need to implement the `JsonNaming` trait:

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -252,7 +252,7 @@ class ScalaJsonAutomatedSpec extends Specification {
         readAnyRole(contributorJson) must_=== JsSuccess(sampleContributor)
       }
     }
-    
+
     "automatically convert custom JSON for a sealed family" in {
       //#trait-custom-representation
       val adminJson = Json.parse("""

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -256,12 +256,12 @@ class ScalaJsonAutomatedSpec extends Specification {
     "automatically convert custom JSON for a sealed family" in {
       //#trait-custom-representation
       val adminJson = Json.parse("""
-        { "admTpe": "scalaguide.json.ScalaJsonAutomatedSpec.Admin" }
+        { "admTpe": "admin" }
       """)
 
       val contributorJson = Json.parse("""
         {
-          "admTpe":"scalaguide.json.ScalaJsonAutomatedSpec.Contributor",
+          "admTpe":"contributor",
           "organization":"Foo"
         }
       """)

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -272,13 +272,12 @@ class ScalaJsonAutomatedSpec extends Specification {
 
       implicit val cfg = JsonConfiguration(
         // Each JSON objects is marked with the admTpe, ...
-        discriminator = "admTpe", 
+        discriminator = "admTpe",
 
         // ... indicating the lower-cased name of sub-type
         typeNaming = JsonNaming { fullName =>
           fullName.drop(39 /* remove pkg */ ).toLowerCase
-        }
-      })
+        })
 
       // First provide instance for each sub-types 'Admin' and 'Contributor':
       implicit val adminFormat = OFormat[Admin.type](

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -204,7 +204,7 @@ class ScalaJsonAutomatedSpec extends Specification {
       residentFromJson.get must_=== sampleData
     }
 
-    "automatically convert JSON to a sealed family" in {
+    "automatically convert JSON for a sealed family" in {
       //#trait-representation
       val adminJson = Json.parse("""
         { "_type": "scalaguide.json.ScalaJsonAutomatedSpec.Admin" }
@@ -237,6 +237,62 @@ class ScalaJsonAutomatedSpec extends Specification {
       // Finally able to generate format for the sealed family 'Role'
       implicit val roleFormat: OFormat[Role] = Json.format[Role]
       //#auto-JSON-sealed-trait
+
+      def writeAnyRole(role: Role) = Json.toJson(role)
+
+      def readAnyRole(input: JsValue): JsResult[Role] = input.validate[Role]
+
+      val sampleContributor = Contributor("Foo")
+
+      writeAnyRole(Admin) must_=== adminJson and {
+        writeAnyRole(sampleContributor) must_=== contributorJson
+      } and {
+        readAnyRole(adminJson) must_=== JsSuccess(Admin)
+      } and {
+        readAnyRole(contributorJson) must_=== JsSuccess(sampleContributor)
+      }
+    }
+    
+    "automatically convert custom JSON for a sealed family" in {
+      //#trait-custom-representation
+      val adminJson = Json.parse("""
+        { "admTpe": "scalaguide.json.ScalaJsonAutomatedSpec.Admin" }
+      """)
+
+      val contributorJson = Json.parse("""
+        {
+          "admTpe":"scalaguide.json.ScalaJsonAutomatedSpec.Contributor",
+          "organization":"Foo"
+        }
+      """)
+      //#trait-custom-representation
+
+      //#auto-JSON-custom-trait
+      import play.api.libs.json._
+
+      implicit val cfg = JsonConfiguration(
+        // Each JSON objects is marked with the admTpe, ...
+        discriminator = "admTpe", 
+
+        // ... indicating the lower-cased name of sub-type
+        typeNaming = JsonNaming { fullName =>
+          fullName.drop(39 /* remove pkg */ ).toLowerCase
+        }
+      })
+
+      // First provide instance for each sub-types 'Admin' and 'Contributor':
+      implicit val adminFormat = OFormat[Admin.type](
+        Reads[Admin.type] {
+          case JsObject(_) => JsSuccess(Admin)
+          case _ => JsError("Empty object expected")
+        },
+        OWrites[Admin.type] { _ => Json.obj() })
+
+      implicit val contributorFormat = Json.format[Contributor]
+
+      // Finally able to generate format for the sealed family 'Role'
+      implicit val roleFormat: OFormat[Role] = Json.format[Role]
+      //#auto-JSON-custom-trait
 
       def writeAnyRole(role: Role) = Json.toJson(role)
 

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -535,7 +535,7 @@ import scala.reflect.macros.blackbox
                   s"No instance of Reads is available for ${t.typeSymbol.fullName} in the implicit scope (Hint: if declared in the same file, make sure it's declared before)"
                 )
               }
-              cq"name if name == $config.classNaming(${t.typeSymbol.fullName}) => $reader.reads(vjs)" :: out
+              cq"name if name == $config.typeNaming(${t.typeSymbol.fullName}) => $reader.reads(vjs)" :: out
             }
           )
         ).reverse)
@@ -577,7 +577,7 @@ import scala.reflect.macros.blackbox
               case jsv => $json.JsObject(Seq("_value" -> jsv))
             }
 
-            jso + ($config.discriminator -> $json.JsString($config.classNaming(${t.typeSymbol.fullName})))
+            jso + ($config.discriminator -> $json.JsString($config.typeNaming(${t.typeSymbol.fullName})))
           }"""
         })
 

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -519,7 +519,14 @@ import scala.reflect.macros.blackbox
         c.abort(c.enclosingPosition, s"Sealed trait ${atpe} is not supported: no known subclasses")
       }
 
-      val typeNaming = (_: Type).typeSymbol.fullName
+      def typeNaming(t: Type): String = {
+        /** Extract "name" from @Discriminator("name") */
+        val annotatedName = t.typeSymbol.annotations.map(_.tree).collectFirst {
+          case Apply(Select(New(tt), TermName("<init>")), List(Literal(Constant(name: String)))) if tt.tpe == typeOf[play.api.libs.json.Discriminator] => name
+        }
+
+        annotatedName getOrElse t.typeSymbol.fullName
+      }
 
       def readLambda: Tree = {
         val resolver = new ImplicitResolver({ orig: Type => orig })

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -519,14 +519,7 @@ import scala.reflect.macros.blackbox
         c.abort(c.enclosingPosition, s"Sealed trait ${atpe} is not supported: no known subclasses")
       }
 
-      def typeNaming(t: Type): String = {
-        /** Extract "name" from @Discriminator("name") */
-        val annotatedName = t.typeSymbol.annotations.map(_.tree).collectFirst {
-          case Apply(Select(New(tt), TermName("<init>")), List(Literal(Constant(name: String)))) if tt.tpe == typeOf[play.api.libs.json.Discriminator] => name
-        }
-
-        annotatedName getOrElse t.typeSymbol.fullName
-      }
+      val typeNaming = (_: Type).typeSymbol.fullName
 
       def readLambda: Tree = {
         val resolver = new ImplicitResolver({ orig: Type => orig })

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -544,13 +544,13 @@ import scala.reflect.macros.blackbox
         ).reverse)
 
         q"""(_: $json.JsValue) match {
-          case obj @ $json.JsObject(_) => obj.value.get("_type") match {
+          case obj @ $json.JsObject(_) => obj.value.get($config.discriminator) match {
              case Some(tjs) => {
                val vjs = obj.value.get("_value").getOrElse(obj)
                tjs.validate[String].flatMap { dis => $cases }
              }
 
-             case _ => $json.JsError($JsPath \ "_type", "error.missing.path")
+             case _ => $json.JsError($JsPath \ $config.discriminator, "error.missing.path")
           }
 
           case _ => $json.JsError("error.expected.jsobject")
@@ -580,7 +580,7 @@ import scala.reflect.macros.blackbox
               case jsv => $json.JsObject(Seq("_value" -> jsv))
             }
 
-            jso + ("_type" -> $json.JsString(${typeNaming(t)}))
+            jso + ($config.discriminator -> $json.JsString(${typeNaming(t)}))
           }"""
         })
 

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -519,8 +519,6 @@ import scala.reflect.macros.blackbox
         c.abort(c.enclosingPosition, s"Sealed trait ${atpe} is not supported: no known subclasses")
       }
 
-      val typeNaming = (_: Type).typeSymbol.fullName
-
       def readLambda: Tree = {
         val resolver = new ImplicitResolver({ orig: Type => orig })
         val cases = Match(q"dis", (
@@ -537,8 +535,7 @@ import scala.reflect.macros.blackbox
                   s"No instance of Reads is available for ${t.typeSymbol.fullName} in the implicit scope (Hint: if declared in the same file, make sure it's declared before)"
                 )
               }
-
-              cq"${typeNaming(t)} => $reader.reads(vjs)" :: out
+              cq"name if name == $config.classNaming(${t.typeSymbol.fullName}) => $reader.reads(vjs)" :: out
             }
           )
         ).reverse)
@@ -580,7 +577,7 @@ import scala.reflect.macros.blackbox
               case jsv => $json.JsObject(Seq("_value" -> jsv))
             }
 
-            jso + ($config.discriminator -> $json.JsString(${typeNaming(t)}))
+            jso + ($config.discriminator -> $json.JsString($config.classNaming(${t.typeSymbol.fullName})))
           }"""
         })
 

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -4,6 +4,10 @@
 
 package play.api.libs.json
 
+import scala.annotation.StaticAnnotation
+
+class Discriminator(name: String) extends StaticAnnotation
+
 /** JSON configuration */
 sealed trait JsonConfiguration {
   /** Compile-time options for the JSON macros */

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -4,10 +4,6 @@
 
 package play.api.libs.json
 
-import scala.annotation.StaticAnnotation
-
-class Discriminator(name: String) extends StaticAnnotation
-
 /** JSON configuration */
 sealed trait JsonConfiguration {
   /** Compile-time options for the JSON macros */

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -9,8 +9,11 @@ sealed trait JsonConfiguration {
   /** Compile-time options for the JSON macros */
   type Opts <: Json.MacroOptions
 
-  /** Naming strategy */
+  /** Naming strategy for class members */
   def naming: JsonNaming
+
+  /** Naming strategy for class names */
+  def classNaming: JsonNaming
 
   /** How options are handled by the macro */
   def optionHandlers: OptionHandlers
@@ -25,7 +28,8 @@ object JsonConfiguration {
   private final class Impl[O <: Json.MacroOptions](
     val naming: JsonNaming = JsonNaming.Identity,
     val optionHandlers: OptionHandlers = OptionHandlers.Default,
-    val discriminator: String = defaultDiscriminator
+    val discriminator: String = defaultDiscriminator,
+    val classNaming: JsonNaming = JsonNaming.Identity
   ) extends JsonConfiguration {
     type Opts = O
 
@@ -47,8 +51,9 @@ object JsonConfiguration {
   def apply[Opts <: Json.MacroOptions: Json.MacroOptions.Default](
     naming: JsonNaming = JsonNaming.Identity,
     optionHandlers: OptionHandlers = OptionHandlers.Default,
-    discriminator: String = defaultDiscriminator
-  ): JsonConfiguration.Aux[Opts] = new Impl(naming, optionHandlers, discriminator)
+    discriminator: String = defaultDiscriminator,
+    classNaming: JsonNaming = JsonNaming.Identity
+  ): JsonConfiguration.Aux[Opts] = new Impl(naming, optionHandlers, discriminator, classNaming)
 
   /** Default configuration instance */
   implicit def default[Opts <: Json.MacroOptions: Json.MacroOptions.Default]: JsonConfiguration.Aux[Opts] = apply()

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -14,6 +14,9 @@ sealed trait JsonConfiguration {
 
   /** How options are handled by the macro */
   def optionHandlers: OptionHandlers
+
+  /** Name of the type discriminator field */
+  def discriminator: String
 }
 
 object JsonConfiguration {
@@ -21,16 +24,21 @@ object JsonConfiguration {
 
   private final class Impl[O <: Json.MacroOptions](
     val naming: JsonNaming = JsonNaming.Identity,
-    val optionHandlers: OptionHandlers = OptionHandlers.Default
+    val optionHandlers: OptionHandlers = OptionHandlers.Default,
+    val discriminator: String = defaultDiscriminator
   ) extends JsonConfiguration {
     type Opts = O
 
-    def this(naming: JsonNaming) = this(naming, OptionHandlers.Default)
+    def this(naming: JsonNaming) = this(naming, OptionHandlers.Default, defaultDiscriminator)
+    def this(naming: JsonNaming, optionHandlers: OptionHandlers) = this(naming, optionHandlers, defaultDiscriminator)
   }
 
   // These methods exist for binary compatibility, since Scala protected methods are public from a binary perspective.
   protected def apply(naming: JsonNaming): JsonConfiguration.Aux[Json.MacroOptions] = new Impl(naming)
+  protected def apply(naming: JsonNaming, optionHandlers: OptionHandlers): JsonConfiguration.Aux[Json.MacroOptions] = new Impl(naming, optionHandlers)
   protected def default: JsonConfiguration.Aux[Json.MacroOptions] = apply()
+
+  val defaultDiscriminator = "_type"
 
   /**
    * @param naming the naming strategy
@@ -38,8 +46,9 @@ object JsonConfiguration {
    */
   def apply[Opts <: Json.MacroOptions: Json.MacroOptions.Default](
     naming: JsonNaming = JsonNaming.Identity,
-    optionHandlers: OptionHandlers = OptionHandlers.Default
-  ): JsonConfiguration.Aux[Opts] = new Impl(naming, optionHandlers)
+    optionHandlers: OptionHandlers = OptionHandlers.Default,
+    discriminator: String = defaultDiscriminator
+  ): JsonConfiguration.Aux[Opts] = new Impl(naming, optionHandlers, discriminator)
 
   /** Default configuration instance */
   implicit def default[Opts <: Json.MacroOptions: Json.MacroOptions.Default]: JsonConfiguration.Aux[Opts] = apply()

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -9,16 +9,19 @@ sealed trait JsonConfiguration {
   /** Compile-time options for the JSON macros */
   type Opts <: Json.MacroOptions
 
-  /** Naming strategy for class members */
+  /** Naming strategy for fields */
   def naming: JsonNaming
 
-  /** Naming strategy for class names */
-  def classNaming: JsonNaming
+  /** Naming strategy for type names */
+  def typeNaming: JsonNaming
 
   /** How options are handled by the macro */
   def optionHandlers: OptionHandlers
 
-  /** Name of the type discriminator field */
+  /**
+   * Name of the type discriminator field
+   * (for sealed family; see [[JsonConfiguration$.defaultDiscriminator]])
+   */
   def discriminator: String
 }
 
@@ -29,7 +32,7 @@ object JsonConfiguration {
     val naming: JsonNaming = JsonNaming.Identity,
     val optionHandlers: OptionHandlers = OptionHandlers.Default,
     val discriminator: String = defaultDiscriminator,
-    val classNaming: JsonNaming = JsonNaming.Identity
+    val typeNaming: JsonNaming = JsonNaming.Identity
   ) extends JsonConfiguration {
     type Opts = O
 
@@ -47,13 +50,15 @@ object JsonConfiguration {
   /**
    * @param naming the naming strategy
    * @param optionHandlers handlers for option
+   * @param discriminator See [[JsonConfiguration.discriminator]]
+   * @param typeNaming See [[JsonConfiguration.typeNaming]]
    */
   def apply[Opts <: Json.MacroOptions: Json.MacroOptions.Default](
     naming: JsonNaming = JsonNaming.Identity,
     optionHandlers: OptionHandlers = OptionHandlers.Default,
     discriminator: String = defaultDiscriminator,
-    classNaming: JsonNaming = JsonNaming.Identity
-  ): JsonConfiguration.Aux[Opts] = new Impl(naming, optionHandlers, discriminator, classNaming)
+    typeNaming: JsonNaming = JsonNaming.Identity
+  ): JsonConfiguration.Aux[Opts] = new Impl(naming, optionHandlers, discriminator, typeNaming)
 
   /** Default configuration instance */
   implicit def default[Opts <: Json.MacroOptions: Json.MacroOptions.Default]: JsonConfiguration.Aux[Opts] = apply()

--- a/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
@@ -553,30 +553,6 @@ class MacroSpec extends WordSpec with MustMatchers
       jsOptional.validate(Json.reads[Optional]).get mustEqual optional
     }
 
-    "handle sealed family with annotated discriminator values" in {
-      implicit val familyFormat: OFormat[FamilyWithDiscriminator] = {
-        implicit val firstFormat: OFormat[FirstWithDiscriminator] = Json.format[FirstWithDiscriminator]
-        implicit val secondFormat: OFormat[SecondWithDiscriminator] = Json.format[SecondWithDiscriminator]
-        Json.format[FamilyWithDiscriminator]
-      }
-
-      val first = FirstWithDiscriminator("test")
-      val firstJson = JsObject(Map(
-        "x" -> JsString("test"),
-        "_type" -> JsString("first")
-      ))
-      Json.toJsObject(first) mustEqual firstJson
-      Json.fromJson[FamilyWithDiscriminator](firstJson).get mustEqual first
-
-      val second = SecondWithDiscriminator("test")
-      val secondJson = JsObject(Map(
-        "y" -> JsString("test"),
-        "_type" -> JsString("second")
-      ))
-      Json.toJsObject(second) mustEqual secondJson
-      Json.fromJson[FamilyWithDiscriminator](secondJson).get mustEqual second
-    }
-
     "handle case objects as empty JsObject" in {
       case object Obj
       val writer = Json.writes[Obj.type]
@@ -599,15 +575,6 @@ class MacroSpec extends WordSpec with MustMatchers
   case class Optional(prop: Option[String]) extends Family
 
   sealed trait EmptyFamily
-
-  sealed trait FamilyWithDiscriminator
-
-  @Discriminator("first")
-  case class FirstWithDiscriminator(x: String) extends FamilyWithDiscriminator
-
-  final val SecondDiscriminator = "second"
-  @Discriminator(SecondDiscriminator)
-  case class SecondWithDiscriminator(y: String) extends FamilyWithDiscriminator
 
   object FamilyCodec {
     implicit val simpleWrites = Json.writes[Simple]

--- a/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
@@ -553,8 +553,8 @@ class MacroSpec extends WordSpec with MustMatchers
       jsOptional.validate(Json.reads[Optional]).get mustEqual optional
     }
 
-    "handle sealed family with classNaming" in {
-      implicit val cfg = JsonConfiguration(classNaming = JsonNaming {
+    "handle sealed family with typeNaming" in {
+      implicit val cfg = JsonConfiguration(typeNaming = JsonNaming {
         case "play.api.libs.json.MacroSpec.Simple" => "simple"
         case "play.api.libs.json.MacroSpec.Optional" => "optional"
       })

--- a/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
@@ -524,6 +524,35 @@ class MacroSpec extends WordSpec with MustMatchers
         get mustEqual (optional)
     }
 
+    "handle sealed family with custom discriminator name" in {
+      implicit val cfg = JsonConfiguration(discriminator = "_discriminator")
+      implicit val simpleWrites = OWrites[Simple] { simple =>
+        Json.obj("bar" -> simple.bar)
+      }
+      implicit val simpleReads = Reads[Simple] { js =>
+        (js \ "bar").validate[String].map(Simple(_))
+      }
+      implicit val optionalFormat: OFormat[Optional] = Json.format[Optional]
+      implicit val familyFormat: OFormat[Family] = Json.format[Family]
+
+      val simple = Simple("foo")
+      val jsSimple = simpleWrites.writes(simple) + (
+        "_discriminator" -> JsString("play.api.libs.json.MacroSpec.Simple")
+      )
+
+      val optional = Optional(None)
+      val jsOptional = optionalFormat.writes(optional) + (
+        "_discriminator" -> JsString("play.api.libs.json.MacroSpec.Optional")
+      )
+
+      Json.toJson[Family](simple) mustEqual jsSimple
+      Json.toJson[Family](optional) mustEqual jsOptional
+      jsSimple.validate[Family].get mustEqual simple
+      jsOptional.validate[Family].get mustEqual optional
+      jsSimple.validate(Json.reads[Simple]).get mustEqual simple
+      jsOptional.validate(Json.reads[Optional]).get mustEqual optional
+    }
+
     "handle case objects as empty JsObject" in {
       case object Obj
       val writer = Json.writes[Obj.type]

--- a/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
@@ -553,6 +553,38 @@ class MacroSpec extends WordSpec with MustMatchers
       jsOptional.validate(Json.reads[Optional]).get mustEqual optional
     }
 
+    "handle sealed family with classNaming" in {
+      implicit val cfg = JsonConfiguration(classNaming = JsonNaming {
+        case "play.api.libs.json.MacroSpec.Simple" => "simple"
+        case "play.api.libs.json.MacroSpec.Optional" => "optional"
+      })
+      implicit val simpleWrites = OWrites[Simple] { simple =>
+        Json.obj("bar" -> simple.bar)
+      }
+      implicit val simpleReads = Reads[Simple] { js =>
+        (js \ "bar").validate[String].map(Simple(_))
+      }
+      implicit val optionalFormat: OFormat[Optional] = Json.format[Optional]
+      implicit val familyFormat: OFormat[Family] = Json.format[Family]
+
+      val simple = Simple("foo")
+      val jsSimple = simpleWrites.writes(simple) + (
+        "_type" -> JsString("simple")
+      )
+
+      val optional = Optional(None)
+      val jsOptional = optionalFormat.writes(optional) + (
+        "_type" -> JsString("optional")
+      )
+
+      Json.toJson[Family](simple) mustEqual jsSimple
+      Json.toJson[Family](optional) mustEqual jsOptional
+      jsSimple.validate[Family].get mustEqual simple
+      jsOptional.validate[Family].get mustEqual optional
+      jsSimple.validate(Json.reads[Simple]).get mustEqual simple
+      jsOptional.validate(Json.reads[Optional]).get mustEqual optional
+    }
+
     "handle case objects as empty JsObject" in {
       case object Obj
       val writer = Json.writes[Obj.type]

--- a/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
@@ -553,6 +553,30 @@ class MacroSpec extends WordSpec with MustMatchers
       jsOptional.validate(Json.reads[Optional]).get mustEqual optional
     }
 
+    "handle sealed family with annotated discriminator values" in {
+      implicit val familyFormat: OFormat[FamilyWithDiscriminator] = {
+        implicit val firstFormat: OFormat[FirstWithDiscriminator] = Json.format[FirstWithDiscriminator]
+        implicit val secondFormat: OFormat[SecondWithDiscriminator] = Json.format[SecondWithDiscriminator]
+        Json.format[FamilyWithDiscriminator]
+      }
+
+      val first = FirstWithDiscriminator("test")
+      val firstJson = JsObject(Map(
+        "x" -> JsString("test"),
+        "_type" -> JsString("first")
+      ))
+      Json.toJsObject(first) mustEqual firstJson
+      Json.fromJson[FamilyWithDiscriminator](firstJson).get mustEqual first
+
+      val second = SecondWithDiscriminator("test")
+      val secondJson = JsObject(Map(
+        "y" -> JsString("test"),
+        "_type" -> JsString("second")
+      ))
+      Json.toJsObject(second) mustEqual secondJson
+      Json.fromJson[FamilyWithDiscriminator](secondJson).get mustEqual second
+    }
+
     "handle case objects as empty JsObject" in {
       case object Obj
       val writer = Json.writes[Obj.type]
@@ -575,6 +599,15 @@ class MacroSpec extends WordSpec with MustMatchers
   case class Optional(prop: Option[String]) extends Family
 
   sealed trait EmptyFamily
+
+  sealed trait FamilyWithDiscriminator
+
+  @Discriminator("first")
+  case class FirstWithDiscriminator(x: String) extends FamilyWithDiscriminator
+
+  final val SecondDiscriminator = "second"
+  @Discriminator(SecondDiscriminator)
+  case class SecondWithDiscriminator(y: String) extends FamilyWithDiscriminator
 
   object FamilyCodec {
     implicit val simpleWrites = Json.writes[Simple]


### PR DESCRIPTION
Currently the macro uses a `_type` field with the class name, ie.
```json
{ "_type" : "fully.qualified.ClassName" }
```

This change allows both the name and value to be customized.
```scala
sealed trait Base
@Discriminator("foo") case class Foo(x: Int) extends Base
@Discriminator("bar") case class Bar(y: String) extends Base

implicit val cfg = JsonConfiguration(discriminator = "_discriminator")
```

In this example the JSON would look like
```json
{ "_discriminator": "foo", "x": 42 }
```