### PR TITLE
Added test for dynamically generated case class default values

### DIFF
--- a/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/MacroSpec.scala
@@ -327,6 +327,24 @@ class MacroSpec extends WordSpec with MustMatchers
       )
     }
 
+    "handle case class with dynamic default values" when {
+      val json = Json.obj()
+
+      def readSpec(r: Reads[WithDynamicDefault]) = {
+        r.reads(json).get.uuid must not equal r.reads(json).get.uuid
+      }
+
+      val jsWithDefaults = Json.using[Json.WithDefaultValues]
+
+      "to generate Reads" in readSpec(
+        jsWithDefaults.reads[WithDynamicDefault]
+      )
+
+      "to generate Format" in readSpec(
+        jsWithDefaults.format[WithDynamicDefault]
+      )
+    }
+
     "handle case class with default values inner optional case class containing default values" when {
       implicit val cfg = JsonConfiguration(JsonNaming.Identity)
       implicit val withDefaultFormat = Json.using[Json.MacroOptions with Json.DefaultValues].format[WithDefault]
@@ -572,6 +590,9 @@ class MacroSpec extends WordSpec with MustMatchers
   case class Complex[T, U](id: Int, a: T, b: Either[T, String], c: U)
 
   case class WithDefault(id: Int, a: String = "a", b: Option[String] = Some("b"))
+  case class WithDynamicDefault(
+    uuid: java.util.UUID = java.util.UUID.randomUUID()
+  )
   case class ComplexWithDefault(id: Int, ref: Option[WithDefault] = Some(WithDefault(1)))
 
   case class WithImplicit1(pos: Int, text: String)(implicit x: Numeric[Int])


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

Add test for dynamically generated case class default values
Usecase: automatically generated model id if no id is provided in JSON - should be unique for every JSON reading.

## Background Context

Since it didn't work in v0.6.7 but works now I thought it worth adding a test for this case.

