### PR TITLE
Make JsObject.underlying public

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
@@ -121,9 +121,7 @@ object JsArray extends (IndexedSeq[JsValue] => JsArray) {
 /**
  * Represent a Json object value.
  */
-case class JsObject(
-  private[json] val underlying: Map[String, JsValue]
-) extends JsValue {
+case class JsObject(underlying: Map[String, JsValue]) extends JsValue {
 
   /**
    * The fields of this JsObject in the order passed to to constructor


### PR DESCRIPTION
Having a private case class field interferes with automatic typeclass derivation for both Shapeless and Magnolia.
Exposing JsObject's (possibly mutable) internal structure is consistent with JsArray.