### PR TITLE
Add `forall` method to `JsResult` with `Option#forall` semantics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,6 +142,7 @@ lazy val `play-json` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsResult.recoverWith"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.Writes.contramap"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.OWrites.contramap"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.JsResult.forall"),
 
       // Scala 2.13.0-M4
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.json.LowPriorityDefaultReads.traversableReads"),

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
@@ -24,7 +24,7 @@ case class JsSuccess[T](value: T, path: JsPath = JsPath()) extends JsResult[T] {
   def contains[AA >: T](elem: AA): Boolean = elem == value
 
   def exists(p: T => Boolean): Boolean = p(value)
-  
+
   def forall(p: T => Boolean): Boolean = p(value)
 
   def repath(path: JsPath): JsResult[T] = JsSuccess(value, path ++ this.path)
@@ -68,11 +68,11 @@ case class JsError(errors: collection.Seq[(JsPath, collection.Seq[JsonValidation
   def flatMap[U](f: Nothing => JsResult[U]): JsResult[U] = this
 
   def foreach(f: Nothing => Unit): Unit = ()
-  
+
   def contains[AA >: Nothing](elem: AA): Boolean = false
 
   def exists(p: Nothing => Boolean): Boolean = false
-  
+
   def forall(p: Nothing => Boolean): Boolean = true
 
   def repath(path: JsPath): JsResult[Nothing] =
@@ -224,7 +224,7 @@ sealed trait JsResult[+A] { self =>
 
   /** If this result is successful than check value with predicate '''p''', otherwise return '''false''' */
   def exists(p: A => Boolean): Boolean
-  
+
   /**
    * If this result is successful than check value with predicate '''p''', otherwise return '''true'''.
    * Follows [[Option.forall]] semantics

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
@@ -227,7 +227,7 @@ sealed trait JsResult[+A] { self =>
 
   /**
    * If this result is successful than check value with predicate '''p''', otherwise return '''true'''.
-   * Follows [[Option.forall]] semantics
+   * Follows [[scala.collection.Traversable.forall]] semantics
    */
   def forall(p: A => Boolean): Boolean
 

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
@@ -21,6 +21,8 @@ case class JsSuccess[T](value: T, path: JsPath = JsPath()) extends JsResult[T] {
 
   def foreach(f: T => Unit): Unit = f(value)
 
+  def forall(p: T => Boolean): Boolean = p(value)
+
   def repath(path: JsPath): JsResult[T] = JsSuccess(value, path ++ this.path)
 
   def getOrElse[U >: T](t: => U): U = value
@@ -62,6 +64,8 @@ case class JsError(errors: collection.Seq[(JsPath, collection.Seq[JsonValidation
   def flatMap[U](f: Nothing => JsResult[U]): JsResult[U] = this
 
   def foreach(f: Nothing => Unit): Unit = ()
+
+  def forall(p: Nothing => Boolean): Boolean = true
 
   def repath(path: JsPath): JsResult[Nothing] =
     JsError(errors.map { case (p, s) => path ++ p -> s })
@@ -206,6 +210,12 @@ sealed trait JsResult[+A] { self =>
 
     def withFilter(q: A => Boolean) = new WithFilter(a => p(a) && q(a))
   }
+
+  /**
+   * If this result is successful than check value with predicate '''p''', otherwise return '''true'''.
+   * Follows [[Option.forall]] semantics
+   */
+  def forall(p: A => Boolean): Boolean
 
   /** Updates the JSON path */
   def repath(path: JsPath): JsResult[A]

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsResultSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsResultSpec.scala
@@ -48,4 +48,24 @@ class JsResultSpec extends WordSpec with MustMatchers {
       JsError("err").recoverWith { _ => succ } mustEqual succ
     }
   }
+
+  "JsSuccess#forall" should {
+
+    "return true for JsSuccess(x * 2).forall(_ % 2 == 0)" in {
+      JsSuccess(2).forall(_ % 2 == 0) mustBe true
+    }
+
+    "return false for JsSuccess(x, {x < 0}).forall(_ >)" in {
+      JsSuccess(-1).forall(_ > 0) mustBe false
+    }
+
+  }
+
+  "JsError#forall" should {
+
+    "return true" in {
+      JsError("").forall(_ => false) mustBe true
+    }
+
+  }
 }

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsResultSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsResultSpec.scala
@@ -80,11 +80,11 @@ class JsResultSpec extends WordSpec with MustMatchers {
   "JsSuccess#forall" should {
 
     "return true for JsSuccess(x * 2).forall(_ % 2 == 0)" in {
-      JsSuccess(2).forall(_ % 2 == 0) mustBe true
+      assert(JsSuccess(2).forall(_ % 2 == 0))
     }
 
     "return false for JsSuccess(x, {x < 0}).forall(_ >)" in {
-      JsSuccess(-1).forall(_ > 0) mustBe false
+      assert(!JsSuccess(-1).forall(_ > 0))
     }
 
   }
@@ -92,7 +92,7 @@ class JsResultSpec extends WordSpec with MustMatchers {
   "JsError#forall" should {
 
     "return true" in {
-      JsError("").forall(_ => false) mustBe true
+      assert(JsError("").forall(_ => false))
     }
 
   }

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsResultSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsResultSpec.scala
@@ -76,7 +76,7 @@ class JsResultSpec extends WordSpec with MustMatchers {
     }
 
   }
-  
+
   "JsSuccess#forall" should {
 
     "return true for JsSuccess(x * 2).forall(_ % 2 == 0)" in {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

Adds `forall` method to `JsResult` with `Option#forall` semantics

## References

Initial discussion: https://github.com/playframework/play-json/pull/178
