### PR TITLE
Make it possible to configure the parsing for large big decimals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,8 +154,11 @@ lazy val `play-json` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.json.LowPriorityDefaultReads.traversableReads"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.json.Reads.traversableReads"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.LowPriorityDefaultReads.traversableReads"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.LowPriorityDefaultReads.traversableReads")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.LowPriorityDefaultReads.traversableReads"),
 
+      // Add JsonParseSettings
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.jackson.JsValueDeserializer.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.jackson.PlayDeserializers.this")
     ),
     libraryDependencies ++= jsonDependencies(scalaVersion.value) ++ Seq(
       "org.scalatest" %%% "scalatest" % "3.0.6-SNAP4" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -156,9 +156,11 @@ lazy val `play-json` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.LowPriorityDefaultReads.traversableReads"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.LowPriorityDefaultReads.traversableReads"),
 
-      // Add JsonParseSettings
+      // Add JsonParseSettings, these are all private[jackson] classes
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.jackson.JsValueDeserializer.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.jackson.PlayDeserializers.this")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.jackson.PlayDeserializers.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.jackson.PlaySerializers.this"),
+      ProblemFilters.exclude[MissingClassProblem]("play.api.libs.json.jackson.JsValueSerializer$")
     ),
     libraryDependencies ++= jsonDependencies(scalaVersion.value) ++ Seq(
       "org.scalatest" %%% "scalatest" % "3.0.6-SNAP4" % Test,

--- a/play-json/jvm/src/main/scala/play/api/libs/json/JsonParserSettings.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/JsonParserSettings.scala
@@ -16,18 +16,18 @@ import scala.util.control.NonFatal
  * @param scaleLimit limit the scale, and it is related to the math context used.
  * @param digitsLimit how many digits are accepted, also related to the math context used.
  */
-case class BigDecimalParseSettings(
+final case class BigDecimalParseSettings(
   mathContext: MathContext = MathContext.DECIMAL128,
   scaleLimit: Int,
   digitsLimit: Int
 )
 
-case class BigDecimalSerializerSettings(
+final case class BigDecimalSerializerSettings(
   minPlain: BigDecimal,
   maxPlain: BigDecimal
 )
 
-case class JsonParserSettings(bigDecimalParseSettings: BigDecimalParseSettings, bigDecimalSerializerSettings: BigDecimalSerializerSettings)
+final case class JsonParserSettings(bigDecimalParseSettings: BigDecimalParseSettings, bigDecimalSerializerSettings: BigDecimalSerializerSettings)
 
 object JsonParserSettings {
 

--- a/play-json/jvm/src/main/scala/play/api/libs/json/JsonParserSettings.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/JsonParserSettings.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import java.math.MathContext
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Parse settings for BigDecimals. Defines limits that will be used when parsing the BigDecimals, like how many digits
+ * are accepted.
+ *
+ * @param mathContext the [[MathContext]] used when parsing.
+ * @param scaleLimit limit the scale, and it is related to the math context used.
+ * @param digitsLimit how many digits are accepted, also related to the math context used.
+ */
+case class BigDecimalParseSettings(
+  mathContext: MathContext = MathContext.DECIMAL128,
+  // Limit for the scale considering the MathContext of 128
+  // limit for scale for decimal128: BigDecimal("0." + "0" * 33 + "1e-6143", java.math.MathContext.DECIMAL128).scale + 1
+  scaleLimit: Int = 6178,
+  // 307 digits should be the correct value for 128 bytes. But we are using 310
+  // because Play JSON uses BigDecimal to parse any number including Doubles and
+  // Doubles max value has 309 digits, so we are using 310 here
+  digitsLimit: Int = 310
+)
+
+case class JsonParserSettings(bigDecimalParseSettings: BigDecimalParseSettings = BigDecimalParseSettings())
+
+object JsonParserSettings {
+
+  // Initialize with the default settings. Since most of things happening in play-json are
+  // global, we are using a AtomicReference here. Also notice that these settings should be
+  // changed at application startup and it is not possible yet to re-configured after the
+  // parse is used.
+  //
+  // So, in a Play application, this will be usually configured either using an eager singleton
+  // in in an ApplicationLoader. Other frameworks using play-json should provide their own ways
+  // to do the initialization.
+  private val defaultSettings = new AtomicReference[JsonParserSettings](JsonParserSettings())
+
+  /**
+   * Configure the parse settings.
+   *
+   * @param jsonParserSettings the parse settings that will be used.
+   */
+  def configure(jsonParserSettings: JsonParserSettings): Unit = {
+    defaultSettings.set(jsonParserSettings)
+  }
+
+  /**
+   * Return the parse settings that are configured.
+   */
+  def settings: JsonParserSettings = defaultSettings.get()
+}

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable.{ ArrayBuffer, ListBuffer }
  *   val jsValue = mapper.readValue("""{"foo":"bar"}""", classOf[JsValue])
  * }}}
  */
-class PlayJsonModule(parserSettings: JsonParserSettings) extends SimpleModule("PlayJson", Version.unknownVersion()) {
+final class PlayJsonModule(parserSettings: JsonParserSettings) extends SimpleModule("PlayJson", Version.unknownVersion()) {
   override def setupModule(context: SetupContext): Unit = {
     context.addDeserializers(new PlayDeserializers(parserSettings))
     context.addSerializers(new PlaySerializers(parserSettings))

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -41,7 +41,7 @@ sealed class PlayJsonModule private[jackson] (parserSettings: JsonParserSettings
   }
 }
 
-@deprecated("Use PlayJsonModule class instead")
+@deprecated("Use PlayJsonModule class instead", "2.6.11")
 object PlayJsonModule extends PlayJsonModule(JsonParserSettings())
 
 // -- Serializers.

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -41,7 +41,8 @@ class PlayJsonModule(parserSettings: JsonParserSettings) extends SimpleModule("P
   }
 }
 
-object PlayJsonModule extends PlayJsonModule(JsonParserSettings.settings)
+@deprecated("Use PlayJsonModule class instead")
+object PlayJsonModule extends PlayJsonModule(JsonParserSettings())
 
 // -- Serializers.
 
@@ -246,7 +247,7 @@ private[jackson] class PlaySerializers extends Serializers.Base {
 
 private[json] object JacksonJson {
 
-  private lazy val mapper = (new ObjectMapper).registerModule(PlayJsonModule)
+  private lazy val mapper = (new ObjectMapper).registerModule(new PlayJsonModule(JsonParserSettings.settings))
 
   private lazy val jsonFactory = new JsonFactory(mapper)
 

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -5,7 +5,6 @@
 package play.api.libs.json.jackson
 
 import java.io.{ InputStream, StringWriter }
-import java.math.MathContext
 
 import com.fasterxml.jackson.core._
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
@@ -30,16 +29,19 @@ import scala.collection.mutable.{ ArrayBuffer, ListBuffer }
  * {{{
  *   import com.fasterxml.jackson.databind.ObjectMapper
  *
- *   val mapper = new ObjectMapper().registerModule(PlayJsonModule)
+ *   val jsonParseSettings = JsonParserSettings()
+ *   val mapper = new ObjectMapper().registerModule(PlayJsonModule(jsonParseSettings))
  *   val jsValue = mapper.readValue("""{"foo":"bar"}""", classOf[JsValue])
  * }}}
  */
-object PlayJsonModule extends SimpleModule("PlayJson", Version.unknownVersion()) {
+class PlayJsonModule(parserSettings: JsonParserSettings) extends SimpleModule("PlayJson", Version.unknownVersion()) {
   override def setupModule(context: SetupContext): Unit = {
-    context.addDeserializers(new PlayDeserializers)
+    context.addDeserializers(new PlayDeserializers(parserSettings))
     context.addSerializers(new PlaySerializers)
   }
 }
+
+object PlayJsonModule extends PlayJsonModule(JsonParserSettings.settings)
 
 // -- Serializers.
 
@@ -121,7 +123,7 @@ private[jackson] case class ReadingMap(content: ListBuffer[(String, JsValue)]) e
 
 }
 
-private[jackson] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]) extends JsonDeserializer[Object] {
+private[jackson] class JsValueDeserializer(factory: TypeFactory, klass: Class[_], parserSettings: JsonParserSettings) extends JsonDeserializer[Object] {
 
   override def isCachable: Boolean = true
 
@@ -141,15 +143,15 @@ private[jackson] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]
     // There is a limit of how large the numbers can be since parsing extremely
     // large numbers (think thousand of digits) and operating on the parsed values
     // can potentially cause a DDoS.
-    if (inputLength > JacksonJson.BigDecimalLimits.DigitsLimit) {
+    if (inputLength > parserSettings.bigDecimalParseSettings.digitsLimit) {
       throw new IllegalArgumentException(s"""Number is larger than supported for field "${jp.currentName()}"""")
     }
 
     // Must create the BigDecimal with a MathContext that is consistent with the limits used.
-    val bigDecimal = BigDecimal(inputText, JacksonJson.BigDecimalLimits.DefaultMathContext)
+    val bigDecimal = BigDecimal(inputText, parserSettings.bigDecimalParseSettings.mathContext)
 
     // We should also avoid numbers with scale that are out of a safe limit
-    if (Math.abs(bigDecimal.scale) > JacksonJson.BigDecimalLimits.ScaleLimit) {
+    if (Math.abs(bigDecimal.scale) > parserSettings.bigDecimalParseSettings.scaleLimit) {
       throw new IllegalArgumentException(s"""Number scale (${bigDecimal.scale}) is out of limits for field "${jp.currentName()}"""")
     }
 
@@ -222,11 +224,11 @@ private[jackson] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]
   override val getNullValue = JsNull
 }
 
-private[jackson] class PlayDeserializers extends Deserializers.Base {
+private[jackson] class PlayDeserializers(parserSettings: JsonParserSettings) extends Deserializers.Base {
   override def findBeanDeserializer(javaType: JavaType, config: DeserializationConfig, beanDesc: BeanDescription) = {
     val klass = javaType.getRawClass
     if (classOf[JsValue].isAssignableFrom(klass) || klass == JsNull.getClass) {
-      new JsValueDeserializer(config.getTypeFactory, klass)
+      new JsValueDeserializer(config.getTypeFactory, klass, parserSettings)
     } else null
   }
 }
@@ -244,28 +246,9 @@ private[jackson] class PlaySerializers extends Serializers.Base {
 
 private[json] object JacksonJson {
 
-  /**
-   * Define limits for parsing BigDecimal numbers.
-   *
-   * By default, we are using MathContext.DECIMAL128 and then the limits are define in its terms.
-   */
-  object BigDecimalLimits {
+  private lazy val mapper = (new ObjectMapper).registerModule(PlayJsonModule)
 
-    val DefaultMathContext: MathContext = MathContext.DECIMAL128
-
-    // Limit for the scale considering the MathContext of 128
-    // limit for scale for decimal128: BigDecimal("0." + "0" * 33 + "1e-6143", java.math.MathContext.DECIMAL128).scale + 1
-    val ScaleLimit: Int = 6178
-
-    // 307 digits should be the correct value for 128 bytes. But we are using 310
-    // because Play JSON uses BigDecimal to parse any number including Doubles and
-    // Doubles max value has 309 digits, so we are using 310 here
-    val DigitsLimit: Int = 310
-  }
-
-  private val mapper = (new ObjectMapper).registerModule(PlayJsonModule)
-
-  private val jsonFactory = new JsonFactory(mapper)
+  private lazy val jsonFactory = new JsonFactory(mapper)
 
   private def stringJsonGenerator(out: java.io.StringWriter) =
     jsonFactory.createGenerator(out)

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable.{ ArrayBuffer, ListBuffer }
  *   val jsValue = mapper.readValue("""{"foo":"bar"}""", classOf[JsValue])
  * }}}
  */
-final class PlayJsonModule(parserSettings: JsonParserSettings) extends SimpleModule("PlayJson", Version.unknownVersion()) {
+sealed class PlayJsonModule private[jackson] (parserSettings: JsonParserSettings) extends SimpleModule("PlayJson", Version.unknownVersion()) {
   override def setupModule(context: SetupContext): Unit = {
     context.addDeserializers(new PlayDeserializers(parserSettings))
     context.addSerializers(new PlaySerializers(parserSettings))

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -267,6 +267,8 @@ class JsonSpec extends org.specs2.mutable.Specification {
 
       "for BigDecimals" should {
 
+        val parserSettings = JsonParserSettings.settings
+
         // note: precision refers to `JacksonJson.BigDecimalLimits.DefaultMathContext.getPrecision`
         "maintain precision when parsing BigDecimals within precision limit" in {
           val n = BigDecimal("12345678901234567890.123456789")
@@ -285,12 +287,12 @@ class JsonSpec extends org.specs2.mutable.Specification {
         }
 
         "success when not exceeding the scale limit for positive numbers" in {
-          val withinScaleLimit = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit - 1)
+          val withinScaleLimit = BigDecimal(2, parserSettings.bigDecimalParseSettings.scaleLimit - 1)
           Json.parse(bigNumbersJson(bigDec = withinScaleLimit.toString)).as[BigNumbers].bigDec mustEqual withinScaleLimit
         }
 
         "success when not exceeding the scale limit for negative numbers" in {
-          val withinScaleLimitNegative = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit - 1).unary_-
+          val withinScaleLimitNegative = BigDecimal(2, parserSettings.bigDecimalParseSettings.scaleLimit - 1).unary_-
           Json.parse(bigNumbersJson(bigDec = withinScaleLimitNegative.toString)).as[BigNumbers].bigDec mustEqual { withinScaleLimitNegative }
         }
 
@@ -305,12 +307,12 @@ class JsonSpec extends org.specs2.mutable.Specification {
         }
 
         "fail when exceeding the scale limit for positive numbers" in {
-          val exceedsScaleLimit = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit + 1)
+          val exceedsScaleLimit = BigDecimal(2, parserSettings.bigDecimalParseSettings.scaleLimit + 1)
           Json.parse(bigNumbersJson(bigDec = exceedsScaleLimit.toString)).as[BigNumbers] must throwA[IllegalArgumentException]
         }
 
         "fail when exceeding the scale limit for negative numbers" in {
-          val exceedsScaleLimit = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit + 1).unary_-
+          val exceedsScaleLimit = BigDecimal(2, parserSettings.bigDecimalParseSettings.scaleLimit + 1).unary_-
           Json.parse(bigNumbersJson(bigDec = exceedsScaleLimit.toString)).as[BigNumbers] must throwA[IllegalArgumentException]
         }
 


### PR DESCRIPTION
## Fixes

Fixes #187 

## Purpose

Parsing large big decimals (thing tens of hundred digits) and operating on these numbers
can be very CPU demanding. While play-json currently supports handling large numbers, it
is not practical on real-world applications and can expose them to DoS of service attacks.

This changes the way parsing happens to limit the size of such numbers based on
MathContext.DECIMAL128.