### PR TITLE
Widen Reads for compatible types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,7 @@ lazy val `play-json` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType
   .settings(playJsonMimaSettings)
   .settings(
     mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.json.Reads.widen"),
       // AbstractFunction1 is in scala.runtime and isn't meant to be used by end users
       ProblemFilters.exclude[MissingTypesProblem]("play.api.libs.json.JsArray$"),
       ProblemFilters.exclude[MissingTypesProblem]("play.api.libs.json.JsObject$"),

--- a/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
@@ -16,7 +16,7 @@ import scala.reflect.ClassTag
 @implicitNotFound(
   "No Json serializer found for type ${A}. Try to implement an implicit Writes or Format for this type."
 )
-trait Writes[-A] {
+trait Writes[-A] { self =>
   /**
    * Converts the `A` value into a [[JsValue]].
    */
@@ -26,17 +26,21 @@ trait Writes[-A] {
    * Returns a new instance that first converts a `B` value to a `A` one,
    * before converting this `A` value into a [[JsValue]].
    */
-  def contramap[B](f: B => A): Writes[B] = Writes[B](b => this.writes(f(b)))
+  def contramap[B](f: B => A): Writes[B] = Writes[B](b => self.writes(f(b)))
 
   /**
    * Transforms the resulting [[JsValue]] using transformer function.
    */
-  def transform(transformer: JsValue => JsValue): Writes[A] = Writes[A] { a => transformer(this.writes(a)) }
+  def transform(transformer: JsValue => JsValue): Writes[A] = Writes[A] { a =>
+    transformer(self.writes(a))
+  }
 
   /**
    * Transforms the resulting [[JsValue]] using a `Writes[JsValue]`.
    */
-  def transform(transformer: Writes[JsValue]): Writes[A] = Writes[A] { a => transformer.writes(this.writes(a)) }
+  def transform(transformer: Writes[JsValue]): Writes[A] = Writes[A] { a =>
+    transformer.writes(self.writes(a))
+  }
 }
 
 @implicitNotFound(

--- a/play-json/shared/src/test/scala/play/api/libs/json/ReadsSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/ReadsSharedSpec.scala
@@ -11,8 +11,8 @@ import java.util.Locale
 import org.scalatest._
 
 class ReadsSharedSpec extends WordSpec with MustMatchers {
-  "Reads flatMap" should {
-    "not repath the second result" when {
+  "Reads" should {
+    "not repath the second result on flatMap" when {
       val aPath = JsPath \ "a"
       val readsA: Reads[String] = aPath.read[String]
       val value = "string"
@@ -32,6 +32,22 @@ class ReadsSharedSpec extends WordSpec with MustMatchers {
             JsonValidationError("error.expected.jsnumber")
           )))))
       }
+    }
+
+    "widen" in {
+      // !! Keep type ascriptions
+      val orig: Reads[List[String]] = implicitly[Reads[List[String]]]
+      val widened: Reads[Traversable[String]] = orig.widen
+
+      widened.reads(JsArray(Seq(JsString("foo"), JsString("bar")))).
+        mustEqual(JsSuccess[Traversable[String]](List("foo", "bar")))
+
+    }
+
+    "be failed" in {
+      val r: Reads[String] = Reads.failed[String]("Foo")
+
+      r.reads(Json.obj()) mustEqual JsError("Foo")
     }
   }
 


### PR DESCRIPTION
```scala
import play.api.libs.json.Reads

def simple(r: Reads[Dog]): Reads[Animal] = r.widen[Animal]

def combine(dog: Reads[Dog], cat: Reads[Cat]): Reads[Animal] =
  dog.orElse(cat).orElse(Reads.failed[Animal]("Unsupported Animal"))
```