### PR TITLE
using interplay 2.0.4

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.3"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.4"))
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.2")
 


### PR DESCRIPTION
Updates interplay to 2.0.4

This will force the releases to build for `2.11.12`, `2.12.7` and `2.13.0-M5`. Dropping `2.13.0-M4`.

The release build is not working for `2.13.0-M4` because of missing dependencies. This was not previously detected because travis build does not include `2.13.0-M4`, but only `2.13.0-M5`