### PR TITLE
Avoid parsing large big decimals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,7 @@ lazy val commonSettings = SbtScalariform.projectSettings ++ Seq(
     testOptions in Test ++= Seq(
       // Show the duration of tests
       Tests.Argument(TestFrameworks.ScalaTest, "-oD"),
+      Tests.Argument(TestFrameworks.Specs2, "showtimes"),
       // Filtering tests that are not stable in Scala 2.13 yet.
       Tests.Argument(TestFrameworks.ScalaTest, "-l", "play.api.libs.json.UnstableInScala213")
     ),

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -266,6 +266,8 @@ class JsonSpec extends org.specs2.mutable.Specification {
       }
 
       "for BigDecimals" should {
+
+        // note: precision refers to `JacksonJson.BigDecimalLimits.DefaultMathContext.getPrecision`
         "maintain precision when parsing BigDecimals within precision limit" in {
           val n = BigDecimal("12345678901234567890.123456789")
           val json = toJson(n)
@@ -274,6 +276,7 @@ class JsonSpec extends org.specs2.mutable.Specification {
 
         "truncate when exceeding the precision limit" in {
           // last two six are exceeding 34 precision limit
+          // note: precision refers to `JacksonJson.BigDecimalLimits.DefaultMathContext.getPrecision`
           val n = BigDecimal("10.12345678912345678912345678912345666")
           val numbers = Json.parse(bigNumbersJson(bigDec = n.toString)).as[BigNumbers]
 

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -274,14 +274,14 @@ class JsonSpec extends org.specs2.mutable.Specification {
           parse(stringify(json)) mustEqual json
         }
 
+        // note: precision refers to `JacksonJson.BigDecimalLimits.DefaultMathContext.getPrecision`
         "truncate when exceeding the precision limit" in {
-          // last two six are exceeding 34 precision limit
-          // note: precision refers to `JacksonJson.BigDecimalLimits.DefaultMathContext.getPrecision`
-          val n = BigDecimal("10.12345678912345678912345678912345666")
+          // last two "3" are exceeding 34 precision limit
+          val n = BigDecimal("10.1234567890123456789012345678901233")
           val numbers = Json.parse(bigNumbersJson(bigDec = n.toString)).as[BigNumbers]
 
-          // Without the last two "6" since they were truncated ("...4566" becomes "...46")
-          numbers.bigDec mustEqual BigDecimal("10.12345678912345678912345678912346")
+          // Without the last two "3" since they were truncated ("...1233" becomes "...12")
+          numbers.bigDec mustEqual BigDecimal("10.12345678901234567890123456789012")
         }
 
         "success when not exceeding the scale limit for positive numbers" in {

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -356,7 +356,7 @@ class JsonSpec extends org.specs2.mutable.Specification {
         }
 
         "truncate when exceeding the precision limit" in {
-          // lsat two six are exceeding 34 precision limit
+          // last two six are exceeding 34 precision limit
           val n = BigDecimal("10.12345678912345678912345678912345666")
           val numbers = Json.parse(
             s"""

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -148,203 +148,120 @@ class JsonSpec extends org.specs2.mutable.Specification {
     }
 
     "when parsing numbers" in {
+
+      def intsJson(long: String = "1", int: String = "1") = {
+        s"""
+           |{
+           |  "long": $long,
+           |  "integer": $int
+           |}""".stripMargin
+      }
+
+      def floatsJson(float: String = "1.0", double: String = "1.0") = {
+        s"""
+           |{
+           |  "float": $float,
+           |  "double": $double
+           |}""".stripMargin
+      }
+
+      def bigNumbersJson(bigDec: String = BigDecimal(1).toString, bigInt: String = BigInt(1).toString) = {
+        s"""
+           |{
+           |  "bigInt": $bigInt,
+           |  "bigDec": $bigDec
+           |}""".stripMargin
+      }
+
       "for Long" should {
 
         "success for valid positive number" in {
-          Json.parse(
-            s"""
-              |{
-              |  "long": 123,
-              |  "integer": 1
-              |}""".stripMargin)
-            .as[IntNumbers].long mustEqual 123
+          Json.parse(intsJson(long = 123.toString)).as[IntNumbers].long mustEqual 123
         }
 
         "success for valid negative number" in {
-          Json.parse(
-            s"""
-               |{
-               |  "long": -123,
-               |  "integer": 1
-               |}""".stripMargin)
-            .as[IntNumbers].long mustEqual -123
+          Json.parse(intsJson(long = (-123).toString)).as[IntNumbers].long mustEqual -123
         }
 
         "success for max value" in {
-          Json.parse(
-            s"""
-               |{
-               |  "long": ${Long.MaxValue},
-               |  "integer": 1
-               |}""".stripMargin)
-            .as[IntNumbers].long mustEqual Long.MaxValue
+          Json.parse(intsJson(long = Long.MaxValue.toString)).as[IntNumbers].long mustEqual Long.MaxValue
         }
 
         "success for min value" in {
-          Json.parse(
-            s"""
-               |{
-               |  "long": ${Long.MinValue},
-               |  "integer": 1
-               |}""".stripMargin)
-            .as[IntNumbers].long mustEqual Long.MinValue
+          Json.parse(intsJson(long = Long.MinValue.toString)).as[IntNumbers].long mustEqual Long.MinValue
         }
 
         "fail for positive number out of Long limits" in {
           val outOfLimits = BigDecimal(Long.MaxValue) + 10
-          Json.parse(
-            s"""
-               |{
-               |  "long": $outOfLimits,
-               |  "integer": 1
-               |}""".stripMargin)
-            .as[IntNumbers] must throwA[JsResultException]
+          Json.parse(intsJson(long = outOfLimits.toString())).as[IntNumbers] must throwA[JsResultException]
         }
 
         "fail for negative number out of Long limits" in {
           val outOfLimits = BigDecimal(Long.MaxValue) + 10
-          Json.parse(
-            s"""
-               |{
-               |  "long": ${outOfLimits.unary_-},
-               |  "integer": 1
-               |}""".stripMargin)
-            .as[IntNumbers] must throwA[JsResultException]
+          Json.parse(intsJson(long = outOfLimits.unary_-.toString())).as[IntNumbers] must throwA[JsResultException]
         }
       }
 
       "for Integer" should {
 
         "success for valid positive number" in {
-          Json.parse(
-            s"""
-               |{
-               |  "long": 1,
-               |  "integer": 123
-               |}""".stripMargin)
-            .as[IntNumbers].integer mustEqual 123
+          Json.parse(intsJson(int = 123.toString)).as[IntNumbers].integer mustEqual 123
         }
 
         "success for valid negative number" in {
-          Json.parse(
-            s"""
-               |{
-               |  "long": 1,
-               |  "integer": -123
-               |}""".stripMargin)
-            .as[IntNumbers].integer mustEqual -123
+          Json.parse(intsJson(int = (-123).toString)).as[IntNumbers].integer mustEqual -123
         }
 
         "fail for positive number out of Int limits" in {
           val outOfLimits = BigDecimal(Int.MaxValue) + 10
-          Json.parse(
-            s"""
-               |{
-               |  "long": 1,
-               |  "integer": $outOfLimits
-               |}""".stripMargin)
-            .as[IntNumbers] must throwA[JsResultException]
+          Json.parse(intsJson(int = outOfLimits.toString())).as[IntNumbers] must throwA[JsResultException]
         }
 
         "fail for negative number out of Int limits" in {
           val outOfLimits = BigDecimal(Int.MaxValue) + 10
-          Json.parse(
-            s"""
-               |{
-               |  "long": 1,
-               |  "integer": ${outOfLimits.unary_-}
-               |}""".stripMargin)
-            .as[IntNumbers] must throwA[JsResultException]
+          Json.parse(intsJson(int = outOfLimits.unary_-.toString())).as[IntNumbers] must throwA[JsResultException]
         }
       }
 
       "for Float" should {
 
         "success for valid positive number" in {
-          Json.parse(
-            s"""
-               |{
-               |  "float": 123.123,
-               |  "double": 1
-               |}""".stripMargin)
-            .as[FloatNumbers].float mustEqual 123.123f
+          Json.parse(floatsJson(123.123.toString)).as[FloatNumbers].float mustEqual 123.123f
         }
 
         "success for valid negative number" in {
-          Json.parse(
-            s"""
-               |{
-               |  "float": -123.123,
-               |  "double": 1
-               |}""".stripMargin)
-            .as[FloatNumbers].float mustEqual -123.123f
+          Json.parse(floatsJson(float = (-123.123).toString)).as[FloatNumbers].float mustEqual -123.123f
         }
 
         "success for max value" in {
-          val outOfLimits = BigDecimal(Float.MaxValue.toString)
-          Json.parse(
-            s"""
-               |{
-               |  "float": $outOfLimits,
-               |  "double": 1
-               |}""".stripMargin)
-            .as[FloatNumbers].float mustEqual Float.MaxValue
+          val maxFloat = BigDecimal(Float.MaxValue.toString)
+          Json.parse(floatsJson(float = maxFloat.toString())).as[FloatNumbers].float mustEqual Float.MaxValue
         }
 
         "success for min value" in {
-          val outOfLimits = BigDecimal(Float.MinValue.toString)
-          Json.parse(
-            s"""
-               |{
-               |  "float": $outOfLimits,
-               |  "double": 1
-               |}""".stripMargin)
-            .as[FloatNumbers].float mustEqual Float.MinValue
+          val minFloat = BigDecimal(Float.MinValue.toString)
+          Json.parse(floatsJson(float = minFloat.toString())).as[FloatNumbers].float mustEqual Float.MinValue
         }
       }
 
       "for Double" should {
 
         "success for valid positive number" in {
-          Json.parse(
-            s"""
-               |{
-               |  "float": 1,
-               |  "double": 123.123
-               |}""".stripMargin)
-            .as[FloatNumbers].double mustEqual 123.123d
+          Json.parse(floatsJson(double = 123.123.toString)).as[FloatNumbers].double mustEqual 123.123d
         }
 
         "success for valid negative number" in {
-          Json.parse(
-            s"""
-               |{
-               |  "float": 1,
-               |  "double": -123.123
-               |}""".stripMargin)
-            .as[FloatNumbers].double mustEqual -123.123d
+          Json.parse(floatsJson(double = (-123.123).toString)).as[FloatNumbers].double mustEqual -123.123d
         }
 
         "success when parsing max value" in {
-          val outOfLimits = BigDecimal(Double.MaxValue)
-          Json.parse(
-            s"""
-               |{
-               |  "float": 1,
-               |  "double": $outOfLimits
-               |}""".stripMargin)
-            .as[FloatNumbers].double mustEqual Double.MaxValue
+          val maxDouble = BigDecimal(Double.MaxValue)
+          Json.parse(floatsJson(double = maxDouble.toString())).as[FloatNumbers].double mustEqual Double.MaxValue
         }
 
         "success when parsing min value" in {
-          val outOfLimits = BigDecimal(Double.MinValue)
-          Json.parse(
-            s"""
-               |{
-               |  "float": 1,
-               |  "double": $outOfLimits
-               |}""".stripMargin)
-            .as[FloatNumbers].double mustEqual Double.MinValue
+          val minDouble = BigDecimal(Double.MinValue)
+          Json.parse(floatsJson(double = minDouble.toString)).as[FloatNumbers].double mustEqual Double.MinValue
         }
       }
 
@@ -358,13 +275,7 @@ class JsonSpec extends org.specs2.mutable.Specification {
         "truncate when exceeding the precision limit" in {
           // last two six are exceeding 34 precision limit
           val n = BigDecimal("10.12345678912345678912345678912345666")
-          val numbers = Json.parse(
-            s"""
-               |{
-               |  "bigInt": 1,
-               |  "bigDec": $n
-               |}""".stripMargin
-          ).as[BigNumbers]
+          val numbers = Json.parse(bigNumbersJson(bigDec = n.toString)).as[BigNumbers]
 
           // Without the last two "6" since they were truncated ("...4566" becomes "...46")
           numbers.bigDec mustEqual BigDecimal("10.12345678912345678912345678912346")
@@ -372,70 +283,32 @@ class JsonSpec extends org.specs2.mutable.Specification {
 
         "success when not exceeding the scale limit for positive numbers" in {
           val withinScaleLimit = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit - 1)
-          Json.parse(
-            s"""
-                 |{
-                 |  "bigInt": 1,
-                 |  "bigDec": $withinScaleLimit
-                 |}""".stripMargin
-          ).as[BigNumbers].bigDec mustEqual withinScaleLimit
+          Json.parse(bigNumbersJson(bigDec = withinScaleLimit.toString)).as[BigNumbers].bigDec mustEqual withinScaleLimit
         }
 
         "success when not exceeding the scale limit for negative numbers" in {
           val withinScaleLimitNegative = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit - 1).unary_-
-          Json.parse(
-            s"""
-                 |{
-                 |  "bigInt": 1,
-                 |  "bigDec": $withinScaleLimitNegative
-                 |}""".stripMargin
-          ).as[BigNumbers].bigDec mustEqual { withinScaleLimitNegative }
+          Json.parse(bigNumbersJson(bigDec = withinScaleLimitNegative.toString)).as[BigNumbers].bigDec mustEqual { withinScaleLimitNegative }
         }
 
         "success when not exceeding the number of digits limit for negative numbers" in {
           val withinDigitsLimitNegative = BigDecimal(Long.MinValue)
-          Json.parse(
-            s"""
-               |{
-               |  "bigInt": 1,
-               |  "bigDec": $withinDigitsLimitNegative
-
-               |}""".
-              stripMargin
-          ).as[BigNumbers].bigDec mustEqual withinDigitsLimitNegative
+          Json.parse(bigNumbersJson(bigDec = withinDigitsLimitNegative.toString)).as[BigNumbers].bigDec mustEqual withinDigitsLimitNegative
         }
 
         "success when not exceeding the number of digits limit for positive numbers" in {
           val withinDigitsLimit = BigDecimal(Long.MaxValue)
-          Json.parse(
-            s"""
-               |{
-               |  "bigInt": 1,
-               |  "bigDec": $withinDigitsLimit
-               |}""".stripMargin
-          ).as[BigNumbers].bigDec mustEqual withinDigitsLimit
+          Json.parse(bigNumbersJson(bigDec = withinDigitsLimit.toString)).as[BigNumbers].bigDec mustEqual withinDigitsLimit
         }
 
         "fail when exceeding the scale limit for positive numbers" in {
           val exceedsScaleLimit = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit + 1)
-          Json.parse(
-            s"""
-                 |{
-                 |  "bigInt": 1,
-                 |  "bigDec": $exceedsScaleLimit
-                 |}""".stripMargin
-          ).as[BigNumbers] must throwA[IllegalArgumentException]
+          Json.parse(bigNumbersJson(bigDec = exceedsScaleLimit.toString)).as[BigNumbers] must throwA[IllegalArgumentException]
         }
 
         "fail when exceeding the scale limit for negative numbers" in {
           val exceedsScaleLimit = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit + 1).unary_-
-          Json.parse(
-            s"""
-                 |{
-                 |  "bigInt": 1,
-                 |  "bigDec": $exceedsScaleLimit
-                 |}""".stripMargin
-          ).as[BigNumbers] must throwA[IllegalArgumentException]
+          Json.parse(bigNumbersJson(bigDec = exceedsScaleLimit.toString)).as[BigNumbers] must throwA[IllegalArgumentException]
         }
 
         "fail when exceeding the number of digits limit for positive numbers" in {

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -9,8 +9,7 @@ import java.util.{ Calendar, Date, TimeZone }
 import com.fasterxml.jackson.databind.{ JsonNode, ObjectMapper }
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Json._
-
-import scala.collection.immutable.ListMap
+import play.api.libs.json.jackson.JacksonJson
 
 class JsonSpec extends org.specs2.mutable.Specification {
   "JSON" title
@@ -21,6 +20,29 @@ class JsonSpec extends org.specs2.mutable.Specification {
 
   case class Post(body: String, created_at: Option[Date])
 
+  case class BigNumbers(bigInt: BigInt, bigDec: BigDecimal)
+  case class IntNumbers(long: Long, integer: Int)
+  case class FloatNumbers(float: Float, double: Double)
+
+  val exceedsDigitsLimit: BigDecimal = BigDecimal("9" * 1000000)
+  val exceedsDigitsLimitNegative: BigDecimal = exceedsDigitsLimit.unary_-
+
+  val invalidJsonExceedingNumberOfDigits: String = s"""
+     |{
+     |  "bigInt": 1,
+     |  "bigDec": $exceedsDigitsLimit
+     |}""".stripMargin
+
+  val invalidJsonExceedingNumberOfDigitsNegative: String = s"""
+                                                      |{
+                                                      |  "bigInt": 1,
+                                                      |  "bigDec": $exceedsDigitsLimitNegative
+                                                      |}""".stripMargin
+
+  implicit val BigNumbersFormat: Format[BigNumbers] = Json.format[BigNumbers]
+  implicit val IntNumbersFormat: Format[IntNumbers] = Json.format[IntNumbers]
+  implicit val FloatNumbersFormat: Format[FloatNumbers] = Json.format[FloatNumbers]
+
   implicit val PostFormat: Format[Post] = (
     (__ \ 'body).format[String] and
     (__ \ 'created_at).formatNullable[Option[Date]](
@@ -29,7 +51,7 @@ class JsonSpec extends org.specs2.mutable.Specification {
         Writes.optionWithNull(Writes.dateWrites(dateFormat))
       )
     ).inmap(optopt => optopt.flatten, (opt: Option[Date]) => Some(opt))
-  )(Post, unlift(Post.unapply))
+  ) (Post, unlift(Post.unapply))
 
   val LenientPostFormat: Format[Post] = (
     (__ \ 'body).format[String] and
@@ -39,12 +61,13 @@ class JsonSpec extends org.specs2.mutable.Specification {
         Writes.dateWrites(dateFormat)
       )
     )
-  )(Post, unlift(Post.unapply))
+  ) (Post, unlift(Post.unapply))
 
   val mapper = new ObjectMapper()
 
   "Complete JSON should create full object" >> {
     lazy val postDate: Date = dateParser.parse("2011-04-22T13:33:48Z")
+
     def postDateWithTZ(tz: TimeZone): Date = {
       val cal = Calendar.getInstance
       cal.setTime(postDate)
@@ -60,66 +83,369 @@ class JsonSpec extends org.specs2.mutable.Specification {
       Json.parse(postJson).as[Post] aka "parsed" must_== expectedPost
     }
 
-    "with default/lenient date format with millis and UTC zone" in {
-      val postJson =
-        """{"body": "foobar", "created_at": "2011-04-22T13:33:48.000Z"}"""
-      val expectedPost = Post("foobar", Some(postDate))
+    "with default/lenient date format" should {
+      "with default/lenient date format with millis and UTC zone" in {
+        val postJson =
+          """{"body": "foobar", "created_at": "2011-04-22T13:33:48.000Z"}"""
+        val expectedPost = Post("foobar", Some(postDate))
 
-      Json.parse(postJson).as[Post](LenientPostFormat).
-        aka("parsed") must_== expectedPost
+        Json.parse(postJson).as[Post](LenientPostFormat).
+          aka("parsed") must_== expectedPost
+      }
+
+      "with default/lenient date format with millis and ISO8601 zone" in {
+        val cal = Calendar.getInstance(TimeZone getTimeZone "UTC")
+        cal.setTime(postDate)
+        cal.add(Calendar.HOUR_OF_DAY, -5)
+
+        val postJson =
+          """{"body": "foobar", "created_at": "2011-04-22T13:33:48.000+0500"}"""
+        val expectedPost = Post("foobar", Some(cal.getTime))
+
+        Json.parse(postJson).as[Post](LenientPostFormat).
+          aka("parsed") must_== expectedPost
+      }
+
+      "with default/lenient date format with no millis and UTC zone" in {
+        val postJson =
+          """{"body": "foobar", "created_at": "2011-04-22T13:33:48Z"}"""
+        val expectedPost = Post("foobar", Some(postDate))
+
+        Json.parse(postJson).as[Post](LenientPostFormat).
+          aka("parsed") must_== expectedPost
+      }
+
+      "with default/lenient date format with no millis and ISO8601 zone" in {
+        val cal = Calendar.getInstance(TimeZone getTimeZone "UTC")
+        cal.setTime(postDate)
+        cal.add(Calendar.HOUR_OF_DAY, -7)
+
+        val postJson =
+          """{"body": "foobar", "created_at": "2011-04-22T13:33:48+0700"}"""
+        val expectedPost = Post("foobar", Some(cal.getTime))
+
+        Json.parse(postJson).as[Post](LenientPostFormat).
+          aka("parsed") must_== expectedPost
+      }
+
+      "with default/lenient date format with millis" in {
+        val postJson =
+          """{"body": "foobar", "created_at": "2011-04-22T13:33:48.000"}"""
+        val expectedPost = Post("foobar", Some(postDateWithTZ(TimeZone.getDefault)))
+
+        Json.parse(postJson).as[Post](LenientPostFormat).
+          aka("parsed") must_== expectedPost
+      }
+
+      "with default/lenient date format without millis or time zone" in {
+        val postJson =
+          """{"body": "foobar", "created_at": "2011-04-22T13:33:48"}"""
+        val expectedPost = Post("foobar", Some(postDateWithTZ(TimeZone.getDefault)))
+
+        Json.parse(postJson).as[Post](LenientPostFormat).
+          aka("parsed") must_== expectedPost
+      }
     }
 
-    "with default/lenient date format with millis and ISO8601 zone" in {
-      val cal = Calendar.getInstance(TimeZone getTimeZone "UTC")
-      cal.setTime(postDate)
-      cal.add(Calendar.HOUR_OF_DAY, -5)
+    "when parsing numbers" in {
+      "for Long" should {
 
-      val postJson =
-        """{"body": "foobar", "created_at": "2011-04-22T13:33:48.000+0500"}"""
-      val expectedPost = Post("foobar", Some(cal.getTime))
+        "success for valid positive number" in {
+          Json.parse(
+            s"""
+              |{
+              |  "long": 123,
+              |  "integer": 1
+              |}""".stripMargin)
+            .as[IntNumbers].long mustEqual 123
+        }
 
-      Json.parse(postJson).as[Post](LenientPostFormat).
-        aka("parsed") must_== expectedPost
-    }
+        "success for valid negative number" in {
+          Json.parse(
+            s"""
+               |{
+               |  "long": -123,
+               |  "integer": 1
+               |}""".stripMargin)
+            .as[IntNumbers].long mustEqual -123
+        }
 
-    "with default/lenient date format with no millis and UTC zone" in {
-      val postJson =
-        """{"body": "foobar", "created_at": "2011-04-22T13:33:48Z"}"""
-      val expectedPost = Post("foobar", Some(postDate))
+        "success for max value" in {
+          Json.parse(
+            s"""
+               |{
+               |  "long": ${Long.MaxValue},
+               |  "integer": 1
+               |}""".stripMargin)
+            .as[IntNumbers].long mustEqual Long.MaxValue
+        }
 
-      Json.parse(postJson).as[Post](LenientPostFormat).
-        aka("parsed") must_== expectedPost
-    }
+        "success for min value" in {
+          Json.parse(
+            s"""
+               |{
+               |  "long": ${Long.MinValue},
+               |  "integer": 1
+               |}""".stripMargin)
+            .as[IntNumbers].long mustEqual Long.MinValue
+        }
 
-    "with default/lenient date format with no millis and ISO8601 zone" in {
-      val cal = Calendar.getInstance(TimeZone getTimeZone "UTC")
-      cal.setTime(postDate)
-      cal.add(Calendar.HOUR_OF_DAY, -7)
+        "fail for positive number out of Long limits" in {
+          val outOfLimits = BigDecimal(Long.MaxValue) + 10
+          Json.parse(
+            s"""
+               |{
+               |  "long": $outOfLimits,
+               |  "integer": 1
+               |}""".stripMargin)
+            .as[IntNumbers] must throwA[JsResultException]
+        }
 
-      val postJson =
-        """{"body": "foobar", "created_at": "2011-04-22T13:33:48+0700"}"""
-      val expectedPost = Post("foobar", Some(cal.getTime))
+        "fail for negative number out of Long limits" in {
+          val outOfLimits = BigDecimal(Long.MaxValue) + 10
+          Json.parse(
+            s"""
+               |{
+               |  "long": ${outOfLimits.unary_-},
+               |  "integer": 1
+               |}""".stripMargin)
+            .as[IntNumbers] must throwA[JsResultException]
+        }
+      }
 
-      Json.parse(postJson).as[Post](LenientPostFormat).
-        aka("parsed") must_== expectedPost
-    }
+      "for Integer" should {
 
-    "with default/lenient date format with millis" in {
-      val postJson =
-        """{"body": "foobar", "created_at": "2011-04-22T13:33:48.000"}"""
-      val expectedPost = Post("foobar", Some(postDateWithTZ(TimeZone.getDefault)))
+        "success for valid positive number" in {
+          Json.parse(
+            s"""
+               |{
+               |  "long": 1,
+               |  "integer": 123
+               |}""".stripMargin)
+            .as[IntNumbers].integer mustEqual 123
+        }
 
-      Json.parse(postJson).as[Post](LenientPostFormat).
-        aka("parsed") must_== expectedPost
-    }
+        "success for valid negative number" in {
+          Json.parse(
+            s"""
+               |{
+               |  "long": 1,
+               |  "integer": -123
+               |}""".stripMargin)
+            .as[IntNumbers].integer mustEqual -123
+        }
 
-    "with default/lenient date format without millis or time zone" in {
-      val postJson =
-        """{"body": "foobar", "created_at": "2011-04-22T13:33:48"}"""
-      val expectedPost = Post("foobar", Some(postDateWithTZ(TimeZone.getDefault)))
+        "fail for positive number out of Int limits" in {
+          val outOfLimits = BigDecimal(Int.MaxValue) + 10
+          Json.parse(
+            s"""
+               |{
+               |  "long": 1,
+               |  "integer": $outOfLimits
+               |}""".stripMargin)
+            .as[IntNumbers] must throwA[JsResultException]
+        }
 
-      Json.parse(postJson).as[Post](LenientPostFormat).
-        aka("parsed") must_== expectedPost
+        "fail for negative number out of Int limits" in {
+          val outOfLimits = BigDecimal(Int.MaxValue) + 10
+          Json.parse(
+            s"""
+               |{
+               |  "long": 1,
+               |  "integer": ${outOfLimits.unary_-}
+               |}""".stripMargin)
+            .as[IntNumbers] must throwA[JsResultException]
+        }
+      }
+
+      "for Float" should {
+
+        "success for valid positive number" in {
+          Json.parse(
+            s"""
+               |{
+               |  "float": 123.123,
+               |  "double": 1
+               |}""".stripMargin)
+            .as[FloatNumbers].float mustEqual 123.123f
+        }
+
+        "success for valid negative number" in {
+          Json.parse(
+            s"""
+               |{
+               |  "float": -123.123,
+               |  "double": 1
+               |}""".stripMargin)
+            .as[FloatNumbers].float mustEqual -123.123f
+        }
+
+        "success for max value" in {
+          val outOfLimits = BigDecimal(Float.MaxValue.toString)
+          Json.parse(
+            s"""
+               |{
+               |  "float": $outOfLimits,
+               |  "double": 1
+               |}""".stripMargin)
+            .as[FloatNumbers].float mustEqual Float.MaxValue
+        }
+
+        "success for min value" in {
+          val outOfLimits = BigDecimal(Float.MinValue.toString)
+          Json.parse(
+            s"""
+               |{
+               |  "float": $outOfLimits,
+               |  "double": 1
+               |}""".stripMargin)
+            .as[FloatNumbers].float mustEqual Float.MinValue
+        }
+      }
+
+      "for Double" should {
+
+        "success for valid positive number" in {
+          Json.parse(
+            s"""
+               |{
+               |  "float": 1,
+               |  "double": 123.123
+               |}""".stripMargin)
+            .as[FloatNumbers].double mustEqual 123.123d
+        }
+
+        "success for valid negative number" in {
+          Json.parse(
+            s"""
+               |{
+               |  "float": 1,
+               |  "double": -123.123
+               |}""".stripMargin)
+            .as[FloatNumbers].double mustEqual -123.123d
+        }
+
+        "success when parsing max value" in {
+          val outOfLimits = BigDecimal(Double.MaxValue)
+          Json.parse(
+            s"""
+               |{
+               |  "float": 1,
+               |  "double": $outOfLimits
+               |}""".stripMargin)
+            .as[FloatNumbers].double mustEqual Double.MaxValue
+        }
+
+        "success when parsing min value" in {
+          val outOfLimits = BigDecimal(Double.MinValue)
+          Json.parse(
+            s"""
+               |{
+               |  "float": 1,
+               |  "double": $outOfLimits
+               |}""".stripMargin)
+            .as[FloatNumbers].double mustEqual Double.MinValue
+        }
+      }
+
+      "for BigDecimals" should {
+        "maintain precision when parsing BigDecimals within precision limit" in {
+          val n = BigDecimal("12345678901234567890.123456789")
+          val json = toJson(n)
+          parse(stringify(json)) mustEqual json
+        }
+
+        "truncate when exceeding the precision limit" in {
+          // lsat two six are exceeding 34 precision limit
+          val n = BigDecimal("10.12345678912345678912345678912345666")
+          val numbers = Json.parse(
+            s"""
+               |{
+               |  "bigInt": 1,
+               |  "bigDec": $n
+               |}""".stripMargin
+          ).as[BigNumbers]
+
+          // Without the last two "6" since they were truncated ("...4566" becomes "...46")
+          numbers.bigDec mustEqual BigDecimal("10.12345678912345678912345678912346")
+        }
+
+        "success when not exceeding the scale limit for positive numbers" in {
+          val withinScaleLimit = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit - 1)
+          Json.parse(
+            s"""
+                 |{
+                 |  "bigInt": 1,
+                 |  "bigDec": $withinScaleLimit
+                 |}""".stripMargin
+          ).as[BigNumbers].bigDec mustEqual withinScaleLimit
+        }
+
+        "success when not exceeding the scale limit for negative numbers" in {
+          val withinScaleLimitNegative = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit - 1).unary_-
+          Json.parse(
+            s"""
+                 |{
+                 |  "bigInt": 1,
+                 |  "bigDec": $withinScaleLimitNegative
+                 |}""".stripMargin
+          ).as[BigNumbers].bigDec mustEqual { withinScaleLimitNegative }
+        }
+
+        "success when not exceeding the number of digits limit for negative numbers" in {
+          val withinDigitsLimitNegative = BigDecimal(Long.MinValue)
+          Json.parse(
+            s"""
+               |{
+               |  "bigInt": 1,
+               |  "bigDec": $withinDigitsLimitNegative
+
+               |}""".
+              stripMargin
+          ).as[BigNumbers].bigDec mustEqual withinDigitsLimitNegative
+        }
+
+        "success when not exceeding the number of digits limit for positive numbers" in {
+          val withinDigitsLimit = BigDecimal(Long.MaxValue)
+          Json.parse(
+            s"""
+               |{
+               |  "bigInt": 1,
+               |  "bigDec": $withinDigitsLimit
+               |}""".stripMargin
+          ).as[BigNumbers].bigDec mustEqual withinDigitsLimit
+        }
+
+        "fail when exceeding the scale limit for positive numbers" in {
+          val exceedsScaleLimit = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit + 1)
+          Json.parse(
+            s"""
+                 |{
+                 |  "bigInt": 1,
+                 |  "bigDec": $exceedsScaleLimit
+                 |}""".stripMargin
+          ).as[BigNumbers] must throwA[IllegalArgumentException]
+        }
+
+        "fail when exceeding the scale limit for negative numbers" in {
+          val exceedsScaleLimit = BigDecimal(2, JacksonJson.BigDecimalLimits.ScaleLimit + 1).unary_-
+          Json.parse(
+            s"""
+                 |{
+                 |  "bigInt": 1,
+                 |  "bigDec": $exceedsScaleLimit
+                 |}""".stripMargin
+          ).as[BigNumbers] must throwA[IllegalArgumentException]
+        }
+
+        "fail when exceeding the number of digits limit for positive numbers" in {
+          Json.parse(invalidJsonExceedingNumberOfDigits).as[BigNumbers] must throwA[IllegalArgumentException]
+        }
+
+        "fail when exceeding the number of digits limit for negative numbers" in {
+          Json.parse(invalidJsonExceedingNumberOfDigitsNegative).as[BigNumbers] must throwA[IllegalArgumentException]
+        }
+      }
     }
 
     "Optional parameters in JSON should generate post w/o date" in {
@@ -181,19 +507,6 @@ class JsonSpec extends org.specs2.mutable.Specification {
       Json.parse(stream) mustEqual js
     }
 
-    "not lose precision when parsing BigDecimals" in {
-      val n = BigDecimal("12345678901234567890.123456789")
-      val json = toJson(n)
-      parse(stringify(json)) mustEqual json
-    }
-
-    "not lose precision when parsing big integers" in {
-      // By big integers, we just mean integers that overflow long,
-      // since Jackson has different code paths for them from decimals
-      val json = toJson(BigDecimal("123456789012345678901234567890"))
-      parse(stringify(json)) mustEqual json
-    }
-
     "keep isomorphism between serialized and deserialized data" in {
       val original = Json.obj(
         "key1" -> "value1",
@@ -211,5 +524,6 @@ class JsonSpec extends org.specs2.mutable.Specification {
       Json.stringify(parsed) mustEqual originalString
     }
   }
+
 }
 

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -28,16 +28,16 @@ class JsonSpec extends org.specs2.mutable.Specification {
   val exceedsDigitsLimitNegative: BigDecimal = exceedsDigitsLimit.unary_-
 
   val invalidJsonExceedingNumberOfDigits: String = s"""
-     |{
-     |  "bigInt": 1,
-     |  "bigDec": $exceedsDigitsLimit
-     |}""".stripMargin
+    |{
+    |  "bigInt": 1,
+    |  "bigDec": $exceedsDigitsLimit
+    |}""".stripMargin
 
   val invalidJsonExceedingNumberOfDigitsNegative: String = s"""
-                                                      |{
-                                                      |  "bigInt": 1,
-                                                      |  "bigDec": $exceedsDigitsLimitNegative
-                                                      |}""".stripMargin
+    |{
+    |  "bigInt": 1,
+    |  "bigDec": $exceedsDigitsLimitNegative
+    |}""".stripMargin
 
   implicit val BigNumbersFormat: Format[BigNumbers] = Json.format[BigNumbers]
   implicit val IntNumbersFormat: Format[IntNumbers] = Json.format[IntNumbers]

--- a/play-json/jvm/src/test/scala/play/api/libs/json/ReadsSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/ReadsSpec.scala
@@ -6,12 +6,9 @@ package play.api.libs.json
 
 import java.math.{ BigDecimal => JBigDec }
 
-import org.scalatest.prop.TableDrivenPropertyChecks._
-
 import java.util.Locale
 
 import java.time.{
-  Clock,
   Duration => JDuration,
   Instant,
   Period,
@@ -28,9 +25,10 @@ import java.time.format.DateTimeFormatter
 
 import org.specs2.specification.core.Fragment
 
-case class Ipsum(id: Long, value: Either[String, Ipsum])
-
 class ReadsSpec extends org.specs2.mutable.Specification {
+
+  val veryLargeNumber = BigDecimal("9" * 1000000)
+
   "JSON Reads" title
 
   "Local date/time" should {
@@ -660,6 +658,32 @@ class ReadsSpec extends org.specs2.mutable.Specification {
     "be parsed as years" in {
       Json.fromJson[Period](JsNumber(5))(
         Reads.javaPeriodYearsReads) must_== JsSuccess(Period.ofYears(5))
+    }
+  }
+
+  "Long numbers" should {
+
+    val DefaultReads = implicitly[Reads[Long]]
+    import DefaultReads.reads
+
+    "parse a long number" in {
+      reads(JsNumber(JBigDec valueOf 123L)).aka("read long number") must_== JsSuccess(123L)
+    }
+
+    "parse a negative long number" in {
+      reads(JsNumber(JBigDec valueOf -123L)).aka("read long number") must_== JsSuccess(-123L)
+    }
+
+    "not read from invalid number" in {
+      reads(JsNumber(BigDecimal("1000000000e1000000000"))).aka("read long number") must beLike {
+        case JsError((_, JsonValidationError("error.expected.long" :: Nil) :: Nil) :: Nil) => ok
+      }
+    }
+
+    "parse a large long number 2" in {
+      reads(JsNumber(veryLargeNumber)).aka("read long number") must beLike {
+        case JsError((_, JsonValidationError("error.expected.long" :: Nil) :: Nil) :: Nil) => ok
+      }
     }
   }
 }


### PR DESCRIPTION
## Fixes

Fixes #187

## Purpose

Parsing large big decimals (thing tens of hundred digits) and operating on these numbers
can be very CPU demanding. While play-json currently supports handling large numbers, it
is not practical on real-world applications and can expose them to DoS of service attacks.

This changes the way parsing happens to limit the size of such numbers based on
MathContext.DECIMAL128.

## References

This is a resubmission of the initial commits of #191.

Are there any relevant issues / PRs / mailing lists discussions?