### PR TITLE
Make constructor of `JsonPlayModule` public

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable.{ ArrayBuffer, ListBuffer }
  *   val jsValue = mapper.readValue("""{"foo":"bar"}""", classOf[JsValue])
  * }}}
  */
-sealed class PlayJsonModule private[jackson] (parserSettings: JsonParserSettings) extends SimpleModule("PlayJson", Version.unknownVersion()) {
+sealed class PlayJsonModule(parserSettings: JsonParserSettings) extends SimpleModule("PlayJson", Version.unknownVersion()) {
   override def setupModule(context: SetupContext): Unit = {
     context.addDeserializers(new PlayDeserializers(parserSettings))
     context.addSerializers(new PlaySerializers(parserSettings))


### PR DESCRIPTION
The companion object is deprecated since 2.6.11 and the class should be used
instead, but this cannot be instantiated the constructor being
`private[jackson]`.

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Purpose

As suggested [here](https://github.com/playframework/play-json/pull/191#issuecomment-445478630) this makes the constructor of the `PlayJsonModule` class publicly accessible.
