### PR TITLE
Lift restriction in macro generating Reads/Writes for sealed traits

### DIFF
--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -24,7 +24,16 @@ class ScalaJsonAutomatedSpec extends Specification {
   //#model3
   sealed trait Role
   case object Admin extends Role
-  case class Contributor(organization: String) extends Role
+  class Contributor(val organization: String) extends Role {
+    override def equals(obj: Any): Boolean = obj match {
+      case other: Contributor if obj != null ⇒ this.organization == other.organization
+      case _ ⇒ false
+    }
+  }
+  object Contributor {
+    def apply(organization: String): Contributor = new Contributor(organization)
+    def unapply(contributor: Contributor): Option[(String)] = Some(contributor.organization)
+  }
   //#model3
 
   val sampleJson = Json.parse(

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -532,10 +532,7 @@ import scala.reflect.macros.blackbox
         case Some(cls: ClassSymbol) if (
           tpeSym != cls && cls.selfType.baseClasses.contains(tpeSym)
         ) => {
-          val newSub: Set[Type] = if (!cls.isCaseClass) {
-            c.warning(c.enclosingPosition, s"cannot handle class ${cls.fullName}: no case accessor")
-            Set.empty
-          } else if (!cls.typeParams.isEmpty) {
+          val newSub: Set[Type] = if (!cls.typeParams.isEmpty) {
             c.warning(c.enclosingPosition, s"cannot handle class ${cls.fullName}: type parameter not supported")
             Set.empty
           } else Set(cls.selfType)
@@ -547,10 +544,7 @@ import scala.reflect.macros.blackbox
           o.companion == NoSymbol && // not a companion object
           tpeSym != c && o.typeSignature.baseClasses.contains(tpeSym)
         ) => {
-          val newSub: Set[Type] = if (!o.moduleClass.asClass.isCaseClass) {
-            c.warning(c.enclosingPosition, s"cannot handle object ${o.fullName}: no case accessor")
-            Set.empty
-          } else Set(o.typeSignature)
+          val newSub: Set[Type] = Set(o.typeSignature)
 
           allSubclasses(path.tail, subclasses ++ newSub)
         }


### PR DESCRIPTION
When generating Reads/Writes for a sealed trait, there should be no reason to
require that direct known sub-classes have to be case classes, as long as there
are implicit Reads/Writes for those types available.

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

This PR allows sealed trait families to consist of normal classes instead of demanding case classes.

## Background Context

The original macro support required the candidates being case classes. I suppose that is the reason the sealed trait macro implementation demanded sub-classes to be case classes too (two years ago).

The code in `ScalaJsonAutomatedSpec.scala` now demonstrates how to use non-case classes with a sealed trait hierarchy.