### PR TITLE
Update Jackson and other dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val specsBuild = Def.setting[Seq[ModuleID]] {
   Seq("org.specs2" %% "specs2-core" % specsVersion)
 }
 
-val jacksonVersion = "2.9.7"
+val jacksonVersion = "2.9.8"
 val jacksons = Seq(
   "com.fasterxml.jackson.core" % "jackson-core",
   "com.fasterxml.jackson.core" % "jackson-annotations",
@@ -34,7 +34,7 @@ val jacksons = Seq(
 ).map(_ % jacksonVersion)
 
 val joda = Seq(
-  "joda-time" % "joda-time" % "2.9.9"
+  "joda-time" % "joda-time" % "2.10.1"
     //"org.joda" % "joda-convert" % "1.8.1")
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.4"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("2.0.5"))
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.2")
 
@@ -18,6 +18,6 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")


### PR DESCRIPTION
## Purpose

Mainly to update Jackson to 2.9.8. But also opportunistically update other dependencies.

## References

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8
