### PR TITLE
implicit OFormat should return specific type OFormat

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/Format.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Format.scala
@@ -30,7 +30,10 @@ object OFormat {
 
   }
 
-  implicit def GenericOFormat[T](implicit fjs: Reads[T], tjs: OWrites[T]): Format[T] = apply(fjs, tjs)
+  @deprecated("Use `oFormatFromReadsAndOWrites`", "2.7.0")
+  def GenericOFormat[T](implicit fjs: Reads[T], tjs: OWrites[T]): Format[T] = apply(fjs, tjs)
+
+  implicit def oFormatFromReadsAndOWrites[T](implicit fjs: Reads[T], tjs: OWrites[T]): OFormat[T] = apply(fjs, tjs)
 
   def apply[A](read: JsValue => JsResult[A], write: A => JsObject): OFormat[A] = new OFormat[A] {
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

An `OFormat` is comprised of a `Reads` and `OWrites`. I would expect to be able to implicitly pull an `OFormat` from those, but as it stands, you can only pull a `Format`.