### PR TITLE
Optimize KeyPathNode.apply()

### DIFF
--- a/benchmarks/src/main/scala/play/api/libs/json/JsonDeserialize_01_List.scala
+++ b/benchmarks/src/main/scala/play/api/libs/json/JsonDeserialize_01_List.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play.api.libs.json
 
 import org.openjdk.jmh.annotations._

--- a/benchmarks/src/main/scala/play/api/libs/json/JsonDeserialize_01_List.scala
+++ b/benchmarks/src/main/scala/play/api/libs/json/JsonDeserialize_01_List.scala
@@ -1,0 +1,36 @@
+package play.api.libs.json
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Benchmark)
+class JsonDeserialize_01_List {
+
+  var employees: Seq[Employee] = _
+  var employeesJson: JsValue = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    val employees: Seq[Employee] = (1 to 100) map { id =>
+      Employee(
+        id,
+        s"Foo$id",
+        s"Bar$id",
+        "New York",
+        "United States",
+        Seq("a", "b", "c")
+      )
+    }
+    employeesJson = Json.toJson(employees)
+  }
+
+  @TearDown(Level.Iteration)
+  def tearDown(): Unit = {
+
+  }
+
+  @Benchmark
+  def jsonAs(): JsValue = {
+    employees = employeesJson.as[Seq[Employee]]
+    employeesJson
+  }
+}

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
@@ -57,7 +57,7 @@ case class RecursiveSearch(key: String) extends PathNode {
 case class KeyPathNode(key: String) extends PathNode {
 
   def apply(json: JsValue): List[JsValue] = json match {
-    case obj: JsObject => List(json \ key).flatMap(_.toOption)
+    case obj: JsObject => obj.underlying.get(key).toList
     case _ => List()
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [X] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Remove unnecessary object allocation and `flatMap` call when processing path in `JsObject`. 

## Purpose

This code optimizes one hot method that we found when we ran benchmark on our application.

