### PR TITLE
Make Writes typeclass invariant

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,3 @@
+-Xss2M
+-XX:+CMSClassUnloadingEnabled
+-XX:ReservedCodeCacheSize=192m

--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
@@ -15,12 +15,16 @@ import play.api.libs.json.jackson.JacksonJson
 trait EnvWrites {
   import scala.language.implicitConversions
 
+  @deprecated("Use `jsonNodeWrites`", "2.8.0")
+  object JsonNodeWrites extends Writes[JsonNode] {
+    def writes(o: JsonNode): JsValue = JacksonJson.jsonNodeToJsValue(o)
+  }
+
   /**
    * Serializer for Jackson JsonNode
    */
-  implicit object JsonNodeWrites extends Writes[JsonNode] {
-    def writes(o: JsonNode): JsValue = JacksonJson.jsonNodeToJsValue(o)
-  }
+  implicit def jsonNodeWrites[T <: JsonNode]: Writes[T] =
+    Writes[T](JacksonJson.jsonNodeToJsValue)
 
   /** Typeclass to implement way of formatting of Java8 temporal types. */
   trait TemporalFormatter[T <: Temporal] {

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
@@ -4,6 +4,8 @@
 
 package play.api.libs.json
 
+import scala.collection.immutable.Map
+
 trait ConstraintFormat {
   @inline def of[A](implicit fmt: Format[A]): Format[A] = fmt
 
@@ -206,13 +208,13 @@ trait ConstraintWrites {
     def writes(a: A): JsValue = JsNull
   }
 
-  def list[A](implicit writes: Writes[A]): Writes[List[A]] = Writes.traversableWrites[A]
+  def list[A](implicit writes: Writes[A]): Writes[List[A]] = Writes.iterableWrites[A, List]
 
-  def set[A](implicit writes: Writes[A]): Writes[Set[A]] = Writes.traversableWrites[A]
+  def set[A](implicit writes: Writes[A]): Writes[Set[A]] = Writes.iterableWrites[A, Set]
 
-  def seq[A](implicit writes: Writes[A]): Writes[Seq[A]] = Writes.traversableWrites[A]
+  def seq[A](implicit writes: Writes[A]): Writes[Seq[A]] = Writes.iterableWrites[A, Seq]
 
-  def map[A](implicit writes: Writes[A]): OWrites[collection.immutable.Map[String, A]] = Writes.mapWrites[A]
+  def map[A](implicit writes: Writes[A]): OWrites[Map[String, A]] = Writes.genericMapWrites[A, Map]
 
   /**
    * Pure Option Writer[T] which writes "null" when None which is different

--- a/play-json/shared/src/test/scala/play/api/libs/json/TupleSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/TupleSpec.scala
@@ -6,22 +6,25 @@ package play.api.libs.json
 
 import org.scalatest._
 
-class TupleSpec extends WordSpec with MustMatchers {
+final class TupleSpec extends WordSpec with MustMatchers {
   "Reading/Write tuples" should {
     def check[T: Reads: Writes](value: T, expected: String) = {
       Json.stringify(Json.toJson(value)) mustEqual expected
       Json.fromJson(Json.parse(expected)).get mustEqual value
     }
+
     "work for small tuples" in {
       check(Tuple1(1), "[1]")
       check((1, 2, "lol"), """[1,2,"lol"]""")
     }
+
     "work for large tuples" in {
       check(
         (1, 2, "lol", "foo", "bar", "baz", true, Seq(1, 2)),
         """[1,2,"lol","foo","bar","baz",true,[1,2]]"""
       )
     }
+
     "work for nested tuples" in {
       check(
         (1, 2, ("lol", ("foo", "bar"))),


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you [added tests](https://github.com/playframework/play-json/commit/6ce9927c3b66750e3c67b4b5c1b59a96e7418e64#diff-3b167857f107248f7299db4e65fbd624) for any changed functionality?

## Fixes

- Fixes #117
- Added [failing tests](https://github.com/playframework/play-json/commit/6ce9927c3b66750e3c67b4b5c1b59a96e7418e64#diff-3b167857f107248f7299db4e65fbd624)

## Purpose

[Make `Writes` typeclass invariant](https://github.com/playframework/play-json/pull/216/files#diff-43f2e42c6ce469bcd932a93a187413feL19).

## Background Context

Contravariance is known to lead to issue for implicit resolution of type class instances.

Also publish locally to check the following projects that depend on `play-json`, to make sure it doesn't break them in unexpected ways.

- playframework: compile and execute tests; no issue
- play-ws: compile and execute tests; no issue
- anorm: [minor update](https://github.com/playframework/anorm/pull/185/files#diff-2e784c46a54980973f4e519474e68f99R70)
- play-scala-starter-example: compile, execute tests and run; no issue
- play-scala-hello-world-tutorial: compile, execute tests and run; no issue
- play-scala-anorm-example: compile, execute tests and run; no issue
- play-scala-forms-example: compile, execute tests and run; no issue
- play-scala-fileupload-example: compile, execute tests and run; no issue
- play-scala-websocket-example: compile, execute tests and run; no issue
- play-chatroom-scala-example: compile, execute tests and run; no issue
- play-scala-streaming-example: compile, execute tests and run; no issue
- play-scala-rest-api-example: compile, execute tests and run; no issue

## References

- [SI-2509](https://issues.scala-lang.org/browse/SI-2509): Contravariance mucks with implicit resolution (created on issue.scala-lang.org 10/2009, updated 8/2016; Open/unresolved)
- [end the blight of contrarivariance](https://groups.google.com/forum/#!topic/scala-language/ZE83TvSWpT4) (On scala-language Google group 5/2012)
- [Implicit Resolution with Contravariance](https://stackoverflow.com/a/21921296) (StackOverflow 2/2014)