### PR TITLE
Fix interaction between DefaultValues and WritesNull

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -714,7 +714,7 @@ import scala.reflect.macros.blackbox
 
           // - If we're an default value, invoke the withDefault version
           // - If we're an option with default value,
-          //   invoke the nullableWithDefault version
+          //   invoke the WithDefault version
           (isOption, defaultValue) match {
             case (true, Some(v)) =>
               val c = TermName(s"${methodName}HandlerWithDefault")

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -717,8 +717,8 @@ import scala.reflect.macros.blackbox
           //   invoke the nullableWithDefault version
           (isOption, defaultValue) match {
             case (true, Some(v)) =>
-              val c = TermName(s"${methodName}NullableWithDefault")
-              q"$jspathTree.$c($v)($impl)"
+              val c = TermName(s"${methodName}HandlerWithDefault")
+              q"$config.optionHandlers.$c($jspathTree, $v)($impl)"
 
             case (true, _) =>
               val c = TermName(s"${methodName}Handler")

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -143,12 +143,17 @@ object JsonNaming {
 
 /** Configure how options should be handled */
 trait OptionHandlers {
-  def readHandler[T](jsPath: JsPath)(implicit r: Reads[T]): Reads[Option[T]]
-  def readHandlerWithDefault[T](jsPath: JsPath, defaultValue: => Option[T])(implicit r: Reads[T]): Reads[Option[T]]
   def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]]
+  def readHandler[T](jsPath: JsPath)(implicit r: Reads[T]): Reads[Option[T]]
+
+  def readHandlerWithDefault[T](jsPath: JsPath, defaultValue: => Option[T])(implicit r: Reads[T]): Reads[Option[T]] = {
+    jsPath.readNullableWithDefault(defaultValue)
+  }
+
   final def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]] = {
     OFormat(readHandler(jsPath), writeHandler(jsPath))
   }
+
   final def formatHandlerWithDefault[T](jsPath: JsPath, defaultValue: => Option[T])(implicit format: Format[T]): OFormat[Option[T]] = {
     OFormat(readHandlerWithDefault(jsPath, defaultValue), writeHandler(jsPath))
   }
@@ -163,7 +168,6 @@ object OptionHandlers {
    */
   object Default extends OptionHandlers {
     def readHandler[T](jsPath: JsPath)(implicit r: Reads[T]): Reads[Option[T]] = jsPath.readNullable
-    def readHandlerWithDefault[T](jsPath: JsPath, defaultValue: => Option[T])(implicit r: Reads[T]): Reads[Option[T]] = jsPath.readNullableWithDefault(defaultValue)
     def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeNullable
   }
 
@@ -173,7 +177,6 @@ object OptionHandlers {
    */
   object WritesNull extends OptionHandlers {
     def readHandler[T](jsPath: JsPath)(implicit reads: Reads[T]): Reads[Option[T]] = jsPath.readNullable
-    def readHandlerWithDefault[T](jsPath: JsPath, defaultValue: => Option[T])(implicit r: Reads[T]): Reads[Option[T]] = jsPath.readNullableWithDefault(defaultValue)
     def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeOptionWithNull
   }
 }

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -144,9 +144,13 @@ object JsonNaming {
 /** Configure how options should be handled */
 trait OptionHandlers {
   def readHandler[T](jsPath: JsPath)(implicit r: Reads[T]): Reads[Option[T]]
+  def readHandlerWithDefault[T](jsPath: JsPath, defaultValue: => Option[T])(implicit r: Reads[T]): Reads[Option[T]]
   def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]]
   final def formatHandler[T](jsPath: JsPath)(implicit format: Format[T]): OFormat[Option[T]] = {
     OFormat(readHandler(jsPath), writeHandler(jsPath))
+  }
+  final def formatHandlerWithDefault[T](jsPath: JsPath, defaultValue: => Option[T])(implicit format: Format[T]): OFormat[Option[T]] = {
+    OFormat(readHandlerWithDefault(jsPath, defaultValue), writeHandler(jsPath))
   }
 }
 
@@ -159,6 +163,7 @@ object OptionHandlers {
    */
   object Default extends OptionHandlers {
     def readHandler[T](jsPath: JsPath)(implicit r: Reads[T]): Reads[Option[T]] = jsPath.readNullable
+    def readHandlerWithDefault[T](jsPath: JsPath, defaultValue: => Option[T])(implicit r: Reads[T]): Reads[Option[T]] = jsPath.readNullableWithDefault(defaultValue)
     def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeNullable
   }
 
@@ -168,6 +173,7 @@ object OptionHandlers {
    */
   object WritesNull extends OptionHandlers {
     def readHandler[T](jsPath: JsPath)(implicit reads: Reads[T]): Reads[Option[T]] = jsPath.readNullable
+    def readHandlerWithDefault[T](jsPath: JsPath, defaultValue: => Option[T])(implicit r: Reads[T]): Reads[Option[T]] = jsPath.readNullableWithDefault(defaultValue)
     def writeHandler[T](jsPath: JsPath)(implicit writes: Writes[T]): OWrites[Option[T]] = jsPath.writeOptionWithNull
   }
 }

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -95,6 +95,7 @@ case class WithDefault2(a: String = "a", bar: Option[WithDefault1] = Some(WithDe
 case class WithDefaultSnake(firstProp: String, defaultProp: String = "the default")
 
 case class Optional(props: Option[String])
+case class OptionalWithDefault(props: Option[String] = None)
 
 class JsonExtensionSpec extends WordSpec with MustMatchers {
   "JsonExtension" should {
@@ -778,6 +779,40 @@ class JsonExtensionSpec extends WordSpec with MustMatchers {
       formatter.reads(Json.obj()) mustEqual JsSuccess(Optional(None))
       formatter.reads(Json.obj("props" -> JsNull)) mustEqual JsSuccess(Optional(None))
       formatter.reads(Json.obj("props" -> Some("foo"))) mustEqual JsSuccess(Optional(Some("foo")))
+    }
+
+    "create a Writes[OptionalWithDefault] with optionHandlers=WritesNull" in {
+      implicit val jsonConfiguration = JsonConfiguration[Json.WithDefaultValues](optionHandlers = OptionHandlers.WritesNull)
+      val writer = Json.writes[OptionalWithDefault]
+      writer.writes(OptionalWithDefault()) mustEqual Json.obj("props" -> JsNull)
+    }
+
+    "create a Format[OptionalWithDefault] with optionHandlers=WritesNull" in {
+      implicit val jsonConfiguration = JsonConfiguration(optionHandlers = OptionHandlers.WritesNull)
+      val formatter = Json.format[OptionalWithDefault]
+      formatter.writes(OptionalWithDefault()) mustEqual Json.obj("props" -> JsNull)
+      formatter.writes(OptionalWithDefault(Some("foo"))) mustEqual Json.obj("props" -> "foo")
+
+      formatter.reads(Json.obj()) mustEqual JsSuccess(OptionalWithDefault())
+      formatter.reads(Json.obj("props" -> JsNull)) mustEqual JsSuccess(OptionalWithDefault())
+      formatter.reads(Json.obj("props" -> Some("foo"))) mustEqual JsSuccess(OptionalWithDefault(Some("foo")))
+    }
+
+    "create a Writes[OptionalWithDefault] with DefaultValues and optionHandlers=WritesNull" in {
+      implicit val jsonConfiguration = JsonConfiguration[Json.WithDefaultValues](optionHandlers = OptionHandlers.WritesNull)
+      val writer = Json.writes[OptionalWithDefault]
+      writer.writes(OptionalWithDefault()) mustEqual Json.obj("props" -> JsNull)
+    }
+
+    "create a Format[OptionalWithDefault] with DefaultValues and optionHandlers=WritesNull" in {
+      implicit val jsonConfiguration = JsonConfiguration[Json.WithDefaultValues](optionHandlers = OptionHandlers.WritesNull)
+      val formatter = Json.format[OptionalWithDefault]
+      formatter.writes(OptionalWithDefault()) mustEqual Json.obj("props" -> JsNull)
+      formatter.writes(OptionalWithDefault(Some("foo"))) mustEqual Json.obj("props" -> "foo")
+
+      formatter.reads(Json.obj()) mustEqual JsSuccess(OptionalWithDefault())
+      formatter.reads(Json.obj("props" -> JsNull)) mustEqual JsSuccess(OptionalWithDefault(None))
+      formatter.reads(Json.obj("props" -> Some("foo"))) mustEqual JsSuccess(OptionalWithDefault(Some("foo")))
     }
   }
 }

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -782,7 +782,7 @@ class JsonExtensionSpec extends WordSpec with MustMatchers {
     }
 
     "create a Writes[OptionalWithDefault] with optionHandlers=WritesNull" in {
-      implicit val jsonConfiguration = JsonConfiguration[Json.WithDefaultValues](optionHandlers = OptionHandlers.WritesNull)
+      implicit val jsonConfiguration = JsonConfiguration(optionHandlers = OptionHandlers.WritesNull)
       val writer = Json.writes[OptionalWithDefault]
       writer.writes(OptionalWithDefault()) mustEqual Json.obj("props" -> JsNull)
     }


### PR DESCRIPTION
When using the `DefaultValues` and `WritesNull` options, the `Json.format` macro doesn't write the `null` value.

```scala
case class CaseClass(prop: Option[Int])
case class CaseClassWithDefault(prop: Option[Int] = None)

implicit val jsonConfiguration = JsonConfiguration[Json.WithDefaultValues](optionHandlers = OptionHandlers.WritesNull)

println(Json.writes[CaseClass].writes(CaseClass(None)))                        // {"prop":null}
println(Json.writes[CaseClassWithDefault].writes(CaseClassWithDefault(None)))  // {"prop":null}
println(Json.format[CaseClass].writes(CaseClass(None)))                        // {"prop":null}
println(Json.format[CaseClassWithDefault].writes(CaseClassWithDefault(None)))  // {}
```