### PR TITLE
Check binary compatibility against 2.7.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ import com.typesafe.sbt.SbtScalariform, SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences._
 
 val previousVersions = Def.setting[Seq[String]] {
-  Seq("2.7.0")
+  Seq("2.7.1")
 }
 
 def playJsonMimaSettings = mimaDefaultSettings ++ Seq(


### PR DESCRIPTION
## Purpose

Binary compatibility was broken when fixing #225 as
noted here:

https://github.com/playframework/play-json/commit/8446ff5a04cb41b373314efa30491324599879a3#commitcomment-32101957

This changes the previous version to 2.7.1 since it is already out.