### PR TITLE
Use unapply for examples

### DIFF
--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
@@ -405,8 +405,8 @@ class ScalaJsonSpec extends Specification {
       // JsSuccess(Resident(Bigwig,6,Some(Owsla)),)
       //#convert-to-model
 
-      placeResult must beLike { case JsSuccess(Place(name, _, _)) => name === "Watership Down" }
-      residentResult must beLike { case Resident(name, _, _) => name === "Bigwig" }
+      placeResult must beLike { case JsSuccess(Place(name, _, _), _) => name === "Watership Down" }
+      residentResult must beLike { case JsSuccess(Resident(name, _, _), _) => name === "Bigwig" }
     }
 
   }

--- a/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
@@ -405,8 +405,8 @@ class ScalaJsonSpec extends Specification {
       // JsSuccess(Resident(Bigwig,6,Some(Owsla)),)
       //#convert-to-model
 
-      placeResult must beLike { case x: JsSuccess[Place] => x.get.name === "Watership Down" }
-      residentResult must beLike { case x: JsSuccess[Resident] => x.get.name === "Bigwig" }
+      placeResult must beLike { case JsSuccess(Place(name, _, _)) => name === "Watership Down" }
+      residentResult must beLike { case Resident(name, _, _) => name === "Bigwig" }
     }
 
   }


### PR DESCRIPTION
Maybe it is better to use alternative syntax, like `case JsSuccess(place) => place.name === name`?

# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [X] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [X] Have you added copyright headers to new files?
* [X] Have you updated the documentation?
* [X] Have you added tests for any changed functionality?

## Fixes

Fixes #239
