### PR TITLE
[2.7.x]: Re add scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     - env: TRAVIS_JDK=adopt@1.11.0-1
 
 scala:
+  - 2.11.12
   - 2.12.8
   - 2.13.0-RC1
 

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val commonSettings = SbtScalariform.projectSettings ++ Seq(
       ))
     },
     scalaVersion := ScalaVersions.scala212,
-    crossScalaVersions := Seq(ScalaVersions.scala212, ScalaVersions.scala213),
+    crossScalaVersions := Seq(ScalaVersions.scala212, ScalaVersions.scala213, "2.11.12"),
     ScalariformKeys.preferences := ScalariformKeys.preferences.value
       .setPreference(SpacesAroundMultiImports, true)
       .setPreference(SpaceInsideParentheses, false)

--- a/build.sbt
+++ b/build.sbt
@@ -50,9 +50,12 @@ val previousVersions = Def.setting[Seq[String]] {
   Seq("2.7.1")
 }
 
-def playJsonMimaSettings = mimaDefaultSettings ++ Seq(
-  mimaPreviousArtifacts := previousVersions.value.map(organization.value %%% moduleName.value % _).toSet
-)
+def playJsonMimaSettings = mimaDefaultSettings ++ {
+  mimaPreviousArtifacts := {
+    if (scalaVersion.value.equals(ScalaVersions.scala213)) Set.empty
+    else previousVersions.value.map(organization.value %%% moduleName.value % _).toSet
+  }
+}
 
 // Workaround for https://github.com/scala-js/scala-js/issues/2378
 // Use "sbt -DscalaJSStage=full" in .travis.yml

--- a/build.sbt
+++ b/build.sbt
@@ -50,12 +50,12 @@ val previousVersions = Def.setting[Seq[String]] {
   Seq("2.7.1")
 }
 
-def playJsonMimaSettings = mimaDefaultSettings ++ {
+def playJsonMimaSettings = mimaDefaultSettings ++ Seq(
   mimaPreviousArtifacts := {
     if (scalaVersion.value.equals(ScalaVersions.scala213)) Set.empty
     else previousVersions.value.map(organization.value %%% moduleName.value % _).toSet
   }
-}
+)
 
 // Workaround for https://github.com/scala-js/scala-js/issues/2378
 // Use "sbt -DscalaJSStage=full" in .travis.yml


### PR DESCRIPTION
It was accidentally removed when backporting #254 to branch 2.7.x.