### PR TITLE
Make macro produce determistic output for sealed subclasses

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -559,7 +559,7 @@ import scala.reflect.macros.blackbox
       }
 
       if (tpeSym.isSealed && tpeSym.isAbstract) {
-        Some(allSubclasses(tpeSym.owner.typeSignature.decls, Set.empty).toList)
+        Some(allSubclasses(tpeSym.owner.typeSignature.decls.sorted, Set.empty).toList)
       } else None
     }
 


### PR DESCRIPTION
`.decls` is documented as having unspecified order. (In practice, 
the order reverses when called on previous compiled vs jointly compiled
types)

This commit follow the instructions in `.decls` ScalaDoc and calls
`.sorted`.

Here's an [example](https://gist.github.com/c1a78e6dffc4e68d0efeb2d6d65841ad) of the non-deterministic output I'm trying to quash.