### PR TITLE
remove unnecessary macro-compat dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,6 @@ lazy val `play-json` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType
       "org.scalatest" %%% "scalatest" % "3.0.8-RC5" % Test,
       "org.scalacheck" %%% "scalacheck" % "1.14.0" % Test,
       "com.chuusai" %% "shapeless" % "2.3.3" % Test,
-      "org.typelevel" %% "macro-compat" % "1.1.1",
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"
     ),
     libraryDependencies ++=

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -11,7 +11,7 @@ import scala.reflect.macros.blackbox
 /**
  * Implementation for the JSON macro.
  */
-@macrocompat.bundle class JsMacroImpl(val c: blackbox.Context) {
+class JsMacroImpl(val c: blackbox.Context) {
   import c.universe._
 
   /** Only for internal purposes */


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

remove macro-compat dependency

## Purpose

remove macro-compat dependency

## Background Context

- unnecessary if cross build with Scala 2.10.x
- macro-compat does not support Scala 2.13.x (?) 🤔  https://github.com/milessabin/macro-compat/pull/85

## References
