### PR TITLE
Fixed obvious typo in SnakeCase JsonNaming leading to first '_' (underscore) to be preserved when converting

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -101,7 +101,7 @@ object JsonNaming {
 
       for (i <- 0 until length) {
         var c = property.charAt(i)
-        if (i > 0 || i != '_') {
+        if (i > 0 || c != '_') {
           if (Character.isUpperCase(c)) {
             // append a underscore if the previous result wasn't translated
             if (!wasPrevTranslated && resultLength > 0 && result.charAt(resultLength - 1) != '_') {

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -14,12 +14,12 @@ import org.scalatest._
 
 case class User(age: Int, name: String)
 case class Dog(name: String, master: User)
-case class UserProfile(firstName: String, lastName: String, zip: Option[String], city: String)
+case class UserProfile(firstName: String, lastName: String, zip: Option[String], _homeCity: String)
 object UserProfile {
   def obj1 = UserProfile("Christian", "Schmitt", None, "Kenzingen")
-  def json1 = Json.obj("first_name" -> "Christian", "last_name" -> "Schmitt", "city" -> "Kenzingen")
-  def json2 = Json.obj("lightbend_firstName" -> "Christian", "lightbend_lastName" -> "Schmitt", "lightbend_city" -> "Kenzingen")
-  def json3 = Json.obj("FirstName" -> "Christian", "LastName" -> "Schmitt", "City" -> "Kenzingen")
+  def json1 = Json.obj("first_name" -> "Christian", "last_name" -> "Schmitt", "home_city" -> "Kenzingen")
+  def json2 = Json.obj("lightbend_firstName" -> "Christian", "lightbend_lastName" -> "Schmitt", "lightbend__homeCity" -> "Kenzingen")
+  def json3 = Json.obj("FirstName" -> "Christian", "LastName" -> "Schmitt", "_homeCity" -> "Kenzingen")
 }
 case class UserProfileHolder(holder: String, profile: UserProfile)
 case class Cat(name: String)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?


## Purpose
Fixes what seems to be original typo in the code that should prevent '_' go as first symbol

## Background Context
Spotted in code
