### PR TITLE
Revert to jackson-databind 2.9.9.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ val specsBuild = Def.setting[Seq[ModuleID]] {
   Seq("org.specs2" %% "specs2-core" % specsVersion)
 }
 
-val jacksonDatabindVersion = "2.9.9.2"
+val jacksonDatabindVersion = "2.9.9.1"
 val jacksonDatabind = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 )


### PR DESCRIPTION
jackson-databind 2.9.9.2 is broken, see https://github.com/FasterXML/jackson-databind/issues/2395#issuecomment-516290566

The tests passed here but Play itself is broken. I'm reverting (https://github.com/playframework/play-json/pull/303) to avoid problems with transitive dependencies. 

We need to wait for 2.9.9.3.