### PR TITLE
Update Travis Jabba settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,12 @@
 language: scala
 
-before_install:
-  - curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
-
-install:
-  - $JABBA_HOME/bin/jabba install $TRAVIS_JDK
-  - unset _JAVA_OPTIONS
-  - export JAVA_HOME="$JABBA_HOME/jdk/$TRAVIS_JDK" && export PATH="$JAVA_HOME/bin:$PATH" && java -Xmx32m -version
+before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
+install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx32m -version
 
 env:
-  global:
-    - JABBA_HOME=$HOME/.jabba
   matrix:
-    - TRAVIS_JDK=adopt@1.8.202-08
-    - TRAVIS_JDK=adopt@1.11.0-2
+    - TRAVIS_JDK=8
+    - TRAVIS_JDK=11
 
 scala:
   - 2.12.8


### PR DESCRIPTION
We have a few builds failing on Travis because of adopt@1.8.0-202-08. 

Strange enough, this was working before. This PR brings a more recent version of it and hopefully, Travis will stop to complain. 


