### PR TITLE
Fix code examples in Scaladoc

### DIFF
--- a/play-functional/src/main/scala/play/api/libs/functional/syntax/package.scala
+++ b/play-functional/src/main/scala/play/api/libs/functional/syntax/package.scala
@@ -10,8 +10,8 @@ import scala.language.implicitConversions
 import play.api.libs.functional._
 
 /**
- * Don't forget to {{{import play.api.libs.functional.syntax._}}} to enable functional combinators
- * when using Json API.
+ * Don't forget to `import play.api.libs.functional.syntax._`
+ * to enable functional combinators when using Json API.
  */
 object `package` {
   implicit def toAlternativeOps[M[_], A](a: M[A])(implicit app: Alternative[M]): AlternativeOps[M, A] =

--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
@@ -311,6 +311,8 @@ trait EnvReads {
    * @see [[DefaultWrites.TemporalFormatter]]
    *
    * {{{
+   * import java.time.format.DateTimeFormatter
+   *
    * import play.api.libs.json.Reads.localDateTimeReads
    *
    * val customReads1 = localDateTimeReads("dd/MM/yyyy, HH:mm:ss")
@@ -346,6 +348,8 @@ trait EnvReads {
    * @see [[DefaultWrites.TemporalFormatter]]
    *
    * {{{
+   * import java.time.format.DateTimeFormatter
+   *
    * import play.api.libs.json.Reads.offsetDateTimeReads
    *
    * val customReads1 = offsetDateTimeReads("dd/MM/yyyy, HH:mm:ss (Z)")
@@ -394,7 +398,10 @@ trait EnvReads {
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
    * @param p Typeclass instance based on `parsing`
    * @see [[DefaultWrites.TemporalFormatter]]
+   *
    * {{{
+   * import java.time.format.DateTimeFormatter
+   *
    * import play.api.libs.json.Reads.zonedDateTimeReads
    *
    * val customReads1 = zonedDateTimeReads("dd/MM/yyyy, HH:mm:ss")
@@ -425,7 +432,10 @@ trait EnvReads {
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
    * @param p Typeclass instance based on `parsing`
    * @see [[DefaultWrites.TemporalFormatter]]
+   *
    * {{{
+   * import java.time.format.DateTimeFormatter
+   *
    * import play.api.libs.json.Reads.localDateReads
    *
    * val customReads1 = localDateReads("dd/MM/yyyy, HH:mm:ss")
@@ -479,7 +489,10 @@ trait EnvReads {
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
    * @param p Typeclass instance based on `parsing`
    * @see [[DefaultWrites.TemporalFormatter]]
+   *
    * {{{
+   * import java.time.format.DateTimeFormatter
+   *
    * import play.api.libs.json.Reads.instantReads
    *
    * val customReads1 = instantReads("dd/MM/yyyy, HH:mm:ss")
@@ -508,7 +521,10 @@ trait EnvReads {
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
    * @param p Typeclass instance based on `parsing`
    * @see [[DefaultWrites.TemporalFormatter]]
+   *
    * {{{
+   * import java.time.format.DateTimeFormatter
+   *
    * import play.api.libs.json.Reads.localTimeReads
    *
    * val customReads1 = localTimeReads("dd/MM/yyyy, HH:mm:ss")

--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
@@ -102,10 +102,12 @@ trait EnvWrites {
    *
    * {{{
    * import java.time.LocalDateTime
+   * import java.time.format.DateTimeFormatter
+   *
    * import play.api.libs.json.Writes
    *
-   * implicit val temporalWrites: Writes[LocalDateTime] =
-   *   temporalWrites[LocalDateTime, DateTimeFormatter](
+   * implicit val w: Writes[LocalDateTime] =
+   *   Writes.temporalWrites[LocalDateTime, DateTimeFormatter](
    *     DateTimeFormatter.ISO_LOCAL_DATE_TIME)
    * }}}
    */
@@ -174,7 +176,7 @@ trait EnvWrites {
    * import java.time.LocalTime
    * import play.api.libs.json.Writes
    *
-   * implicit val ltnWrites = Writes.LocalTimeNumberWrites
+   * implicit val ltnWrites = Writes.LocalTimeNanoOfDayWrites
    * }}}
    */
   val LocalTimeNanoOfDayWrites: Writes[LocalTime] = Writes[LocalTime] { t =>
@@ -232,7 +234,8 @@ trait EnvWrites {
    * import java.time.LocalDate
    * import play.api.libs.json.Writes
    *
-   * implicit val ldnWrites = Writes.LocalDateEpochMilliWrites
+   * implicit val ldnWrites: Writes[LocalDate] =
+   *   Writes.LocalDateEpochMilliWrites
    * }}}
    */
   val LocalDateEpochMilliWrites: Writes[LocalDate] = Writes[LocalDate] { t =>
@@ -251,7 +254,7 @@ trait EnvWrites {
    * import java.time.Instant
    * import play.api.libs.json.Writes
    *
-   * implicit val inWrites = Writes.InstantNumberWrites
+   * implicit val inWrites: Writes[Instant] = Writes.InstantEpochMilliWrites
    * }}}
    */
   val InstantEpochMilliWrites: Writes[Instant] = new Writes[Instant] {

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -7,21 +7,27 @@ package play.api.libs.json.jackson
 import java.io.InputStream
 import java.io.StringWriter
 
-import com.fasterxml.jackson.core._
+import scala.annotation.switch
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.ListBuffer
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonTokenId
+import com.fasterxml.jackson.core.Version
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+
 import com.fasterxml.jackson.databind.Module.SetupContext
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.`type`.TypeFactory
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.Serializers
-import play.api.libs.json._
 
-import scala.annotation.switch
-import scala.annotation.tailrec
-import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
-import scala.collection.mutable.ListBuffer
+import play.api.libs.json._
 
 /**
  * The Play JSON module for Jackson.
@@ -30,11 +36,16 @@ import scala.collection.mutable.ListBuffer
  * with JsValue.  To use this:
  *
  * {{{
- *   import com.fasterxml.jackson.databind.ObjectMapper
+ * import com.fasterxml.jackson.databind.ObjectMapper
  *
- *   val jsonParseSettings = JsonParserSettings()
- *   val mapper = new ObjectMapper().registerModule(PlayJsonModule(jsonParseSettings))
- *   val jsValue = mapper.readValue("""{"foo":"bar"}""", classOf[JsValue])
+ * import play.api.libs.json.JsValue
+ * import play.api.libs.json.jackson.PlayJsonModule
+ * import play.api.libs.json.JsonParserSettings
+ *
+ * val jsonParseSettings = JsonParserSettings()
+ * val mapper = new ObjectMapper().registerModule(
+ *   new PlayJsonModule(jsonParseSettings))
+ * val jsValue = mapper.readValue("""{"foo":"bar"}""", classOf[JsValue])
  * }}}
  */
 sealed class PlayJsonModule(parserSettings: JsonParserSettings)

--- a/play-json/shared/src/main/scala/play/api/libs/json/Json.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Json.scala
@@ -40,16 +40,17 @@ sealed trait JsonFacade {
    * Converts a [[JsValue]] to its string representation.
    *
    * {{{
-   * scala> Json.stringify(Json.obj(
+   * import play.api.libs.json.Json
+   *
+   * val input = Json.obj(
    *   "field1" -> Json.obj(
    *     "field11" -> "value11",
    *     "field12" -> Json.arr("alpha", 123L)
    *   )
-   * ))
-   * res0: String = {"field1":{"field11":"value11","field12":["alpha",123]}}
+   * )
    *
-   * scala> Json.stringify(res0)
-   * res1: String = {"field1":{"field11":"value11","field12":["alpha",123]}}
+   * Json.stringify(input)
+   * // => {"field1":{"field11":"value11","field12":["alpha",123]}}
    * }}}
    *
    * $jsonParam
@@ -74,11 +75,13 @@ sealed trait JsonFacade {
    * (see <a href="http://timelessrepo.com/json-isnt-a-javascript-subset">JSON: The JavaScript subset that isn't</a>).
    *
    * {{{
-   * scala> Json.asciiStringify(JsString("some\u005Cu2028text\u005Cu2029"))
-   * res0: String = "some\u005Cu2028text\u005Cu2029"
+   * import play.api.libs.json.{ Json, JsString }
    *
-   * scala> Json.stringify(JsString("some\u005Cu2028text\u005Cu2029"))
-   * res1: String = "sometext"
+   * Json.asciiStringify(JsString("some\\u005Ctext\\u005C"))
+   * // => "some\\u005Ctext\\u005C"
+   *
+   * Json.stringify(JsString("some\\u005Ctext\\u005C"))
+   * // => "sometext"
    * }}}
    *
    * $jsonParam
@@ -91,22 +94,24 @@ sealed trait JsonFacade {
    * pretty printer (line feeds after each fields and 2-spaces indentation).
    *
    * {{{
-   * scala> Json.stringify(Json.obj(
+   * import play.api.libs.json.Json
+   *
+   * val res0 = Json.obj(
    *   "field1" -> Json.obj(
    *     "field11" -> "value11",
    *     "field12" -> Json.arr("alpha", 123L)
    *   )
-   * ))
-   * res0: String = {"field1":{"field11":"value11","field12":["alpha",123]}}
+   * )
+   * // => {"field1":{"field11":"value11","field12":["alpha",123]}}
    *
-   * scala> Json.prettyPrint(res0)
-   * res1: String =
-   * {
-   *   "field1" : {
-   *     "field11" : "value11",
-   *     "field12" : [ "alpha", 123 ]
-   *   }
-   * }
+   * Json.prettyPrint(res0)
+   * // =>
+   * // {
+   * //   "field1" : {
+   * //     "field11" : "value11",
+   * //     "field12" : [ "alpha", 123 ]
+   * //   }
+   * // }
    * }}}
    *
    * $jsonParam
@@ -191,15 +196,19 @@ object Json extends JsonFacade {
   /**
    * Next is the trait that allows Simplified Json syntax :
    *
-   * Example :
+   * Example:
+   *
    * {{{
+   * import play.api.libs.json._
+   *
    * JsObject(Seq(
    *    "key1" -> JsString("value"),
    *    "key2" -> JsNumber(123),
    *    "key3" -> JsObject(Seq("key31" -> JsString("value31")))
-   * )) == Json.obj( "key1" -> "value", "key2" -> 123, "key3" -> obj("key31" -> "value31"))
+   * )) == Json.obj(
+   *   "key1" -> "value", "key2" -> 123, "key3" -> Json.obj("key31" -> "value31"))
    *
-   * JsArray(JsString("value"), JsNumber(123), JsBoolean(true)) == Json.arr( "value", 123, true )
+   * JsArray(Seq(JsString("value"), JsNumber(123), JsBoolean(true))) == Json.arr("value", 123, true)
    * }}}
    *
    * There is an implicit conversion from any Type with a Json Writes to JsValueWrapper
@@ -231,14 +240,15 @@ object Json extends JsonFacade {
    * $macroTypeParam
    *
    * {{{
-   * import play.api.libs.json.Json
+   * import play.api.libs.functional.syntax._
+   * import play.api.libs.json.{ Json, JsonConfiguration, __ }
    *
    * case class User(userName: String, age: Int)
    *
-   * implicit val userReads = Json.reads[User]
+   * implicit val userReads1 = Json.reads[User]
    * // macro-compiler replaces Json.reads[User] by injecting into compile chain
    * // the exact code you would write yourself. This is strictly equivalent to:
-   * implicit val userReads = (
+   * implicit val userReads2 = (
    *    (__ \ implicitly[JsonConfiguration].naming("userName")).read[String] and
    *    (__ \ implicitly[JsonConfiguration].naming("age")).read[Int]
    * )(User)
@@ -274,17 +284,18 @@ object Json extends JsonFacade {
    * $macroTypeParam
    *
    * {{{
-   *   import play.api.libs.json.Json
+   * import play.api.libs.functional.syntax._
+   * import play.api.libs.json.{ Json, JsonConfiguration, __ }
    *
-   *   case class User(userName: String, age: Int)
+   * case class User(userName: String, age: Int)
    *
-   *   implicit val userWrites = Json.writes[User]
-   *   // macro-compiler replaces Json.writes[User] by injecting into compile chain
-   *   // the exact code you would write yourself. This is strictly equivalent to:
-   *   implicit val userWrites = (
-   *      (__ \ implicitly[JsonConfiguration].naming("userName")).write[String] and
-   *      (__ \ implicitly[JsonConfiguration].naming("age")).write[Int]
-   *   )(unlift(User.unapply))
+   * implicit val userWrites1 = Json.writes[User]
+   * // macro-compiler replaces Json.writes[User] by injecting into compile chain
+   * // the exact code you would write yourself. This is strictly equivalent to:
+   * implicit val userWrites2 = (
+   *    (__ \ implicitly[JsonConfiguration].naming("userName")).write[String] and
+   *    (__ \ implicitly[JsonConfiguration].naming("age")).write[Int]
+   * )(unlift(User.unapply))
    * }}}
    */
   def writes[A]: OWrites[A] = macro JsMacroImpl.implicitConfigWritesImpl[A]
@@ -303,7 +314,7 @@ object Json extends JsonFacade {
    * final class TextId(val value: String) extends AnyVal
    *
    * // Based on provided Writes[String] corresponding to `value: String`
-   * val w: Writes[TextId] = Json.writes[TextId]
+   * val w: Writes[TextId] = Json.valueWrites[TextId]
    * }}}
    */
   def valueWrites[A]: Writes[A] = macro JsMacroImpl.implicitConfigValueWrites[A]
@@ -317,14 +328,15 @@ object Json extends JsonFacade {
    * $macroTypeParam
    *
    * {{{
-   * import play.api.libs.json.Json
+   * import play.api.libs.functional.syntax._
+   * import play.api.libs.json.{ Json, JsonConfiguration, __ }
    *
    * case class User(userName: String, age: Int)
    *
-   * implicit val userWrites = Json.format[User]
+   * val userFormat1 = Json.format[User]
    * // macro-compiler replaces Json.format[User] by injecting into compile chain
    * // the exact code you would write yourself. This is strictly equivalent to:
-   * implicit val userWrites = (
+   * val userFormat2 = (
    *    (__ \ implicitly[JsonConfiguration].naming("userName")).format[String] and
    *    (__ \ implicitly[JsonConfiguration].naming("age")).format[Int]
    * )(User.apply, unlift(User.unapply))
@@ -354,7 +366,7 @@ object Json extends JsonFacade {
    * Creates a `Format[E]` by automatically creating Reads[E] and Writes[E] for any Enumeration E
    *
    * {{{
-   * import play.api.libs.json.Json
+   * import play.api.libs.json.{ Format, Json }
    *
    * object DayOfWeek extends Enumeration {
    *
@@ -365,13 +377,13 @@ object Json extends JsonFacade {
    *  val Wed = Value("Wednesday")
    *  // etc.
    *
-   *   implicit val format: Format[DayOfWeek] = Json.formatEnum(DayOfWeek)
+   *   implicit val format1: Format[DayOfWeek] = Json.formatEnum(DayOfWeek)
    *   // or 'this' if defining directly in Enum
-   *   implicit val format: Format[DayOfWeek] = Json.formatEnum(this)
+   *   implicit val format2: Format[DayOfWeek] = Json.formatEnum(this)
    * }
    * }}}
    *
-   * '''Json.toJson(Mon)''' will produce '''"Monday"'''
+   * `Json.toJson(Mon)` will produce `"Monday"`.
    *
    * @param enum Enumeration object
    * @tparam E type of Enum
@@ -421,7 +433,7 @@ object Json extends JsonFacade {
      * $macroTypeParam
      *
      * {{{
-     * import play.api.libs.json.Json
+     * import play.api.libs.json.{ Json, Reads }
      *
      * case class User(userName: String, age: Int)
      *
@@ -440,7 +452,7 @@ object Json extends JsonFacade {
      * $macroTypeParam
      *
      * {{{
-     * import play.api.libs.json.Json
+     * import play.api.libs.json.{ Json, OWrites }
      *
      * case class User(userName: String, age: Int)
      *
@@ -459,7 +471,7 @@ object Json extends JsonFacade {
      * $macroTypeParam
      *
      * {{{
-     * import play.api.libs.json.Json
+     * import play.api.libs.json.{ Json, OFormat }
      *
      * case class User(userName: String, age: Int)
      *
@@ -476,6 +488,10 @@ object Json extends JsonFacade {
    * @tparam C the type of compile-time configuration
    *
    * {{{
+   * import play.api.libs.json.{ Json, Reads }
+   *
+   * case class Foo(v: String)
+   *
    * // Materializes a `Reads[Foo]`,
    * // with the configuration resolved at compile time
    * val r: Reads[Foo] = Json.configured.reads[Foo]
@@ -495,6 +511,10 @@ object Json extends JsonFacade {
    * Compile-time base options for macro usage.
    *
    * {{{
+   * import play.api.libs.json.Json
+   *
+   * case class Foo(v: String)
+   *
    * Json.using[Json.MacroOptions].format[Foo]
    * // equivalent to Json.format[Foo]
    * }}}
@@ -531,7 +551,9 @@ object Json extends JsonFacade {
    * when applicable.
    *
    * {{{
-   * MacroOptions with DefaultValues
+   * import play.api.libs.json._, Json._
+   *
+   * type Opts = MacroOptions with DefaultValues
    * }}}
    */
   trait DefaultValues { _: MacroOptions =>
@@ -541,7 +563,9 @@ object Json extends JsonFacade {
    * Alias for `MacroOptions with DefaultValues`
    *
    * {{{
-   * Json.using[WithDefaultValues]
+   * import play.api.libs.json.Json
+   *
+   * Json.using[Json.WithDefaultValues]
    * }}}
    */
   type WithDefaultValues = MacroOptions with DefaultValues

--- a/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
@@ -131,10 +131,11 @@ trait Reads[A] { self =>
    * {{{
    * import play.api.libs.json.Reads
    *
-   * def simple(r: Reads[Dog]): Reads[Animal] = r.widen[Animal]
+   * sealed trait Animal
+   * case class Dog(name: String) extends Animal
+   * case class Cat(name: String) extends Animal
    *
-   * def combine(dog: Reads[Dog], cat: Reads[Cat]): Reads[Animal] =
-   *   dog.orElse(cat).orElse(Reads.failed[Animal]("Unsupported Animal"))
+   * def simple(r: Reads[Dog]): Reads[Animal] = r.widen[Animal]
    * }}}
    */
   def widen[B >: A]: Reads[B] = Reads[B] { self.reads(_) }

--- a/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
@@ -135,8 +135,6 @@ object OWrites extends PathWrites with ConstraintWrites {
   /**
    * Transforms the resulting [[JsObject]] using the given function,
    * which is also applied with the initial input.
-   * def transform(transformer: (A, JsObject) => JsObject): OWrites[A] =
-   * OWrites[A] { a => transformer(a, this.writes(a)) }
    *
    * @param w the initial writer
    * @param f the transformer function
@@ -312,6 +310,8 @@ trait DefaultWrites extends LowPriorityWrites {
    * Serializer for JsNull.
    *
    * {{{
+   * import play.api.libs.json.Json
+   *
    * Json.obj("foo" -> None)
    * // equivalent to Json.obj("foo" -> JsNull)
    * }}}
@@ -325,8 +325,11 @@ trait DefaultWrites extends LowPriorityWrites {
    * If `Some` is directly used (not as `Option`).
    *
    * {{{
-   * Json.obj("foo" -> Some(writeableValue))
-   * // equivalent to Json.obj("foo" -> writeableValue)
+   * import play.api.libs.json.{ Json, Writes }
+   *
+   * def foo[T: Writes](writeableValue: T) =
+   *   Json.obj("foo" -> Some(writeableValue))
+   *   // equivalent to Json.obj("foo" -> writeableValue)
    * }}}
    */
   implicit def someWrites[T](implicit w: Writes[T]): Writes[Some[T]] =

--- a/play-json/shared/src/main/scala/play/api/libs/json/package.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/package.scala
@@ -6,7 +6,9 @@ package play.api.libs
 
 /**
  * Json API
+ *
  * For example:
+ *
  * {{{
  * import play.api.libs.json._
  * import play.api.libs.functional.syntax._
@@ -23,15 +25,14 @@ package play.api.libs
  *   )(User.apply, unlift(User.unapply))
  * }
  *
- * //then in a controller:
- *
- * object MyController extends Controller {
+ * object MyController extends play.api.mvc.Controller {
  *    def displayUserAsJson(id: String) = Action {
  *       Ok(Json.toJson(User(id.toLong, "myName")))
  *    }
+ *
  *    def saveUser(jsonString: String)= Action {
  *      val user = Json.parse(jsonString).as[User]
- *      myDataStore.save(user)
+ *      //myDataStore.save(user)
  *      Ok
  *    }
  * }

--- a/play-json/shared/src/test/scala/play/api/libs/json/FakeController.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/FakeController.scala
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.mvc // Allow compile scaladoc without Play dependency
+
+import play.api.libs.json.JsValue
+
+trait Controller {
+  def Ok(r: JsValue)     = ???
+  def Ok                 = ???
+  def Action[T](f: => T) = ???
+}


### PR DESCRIPTION
Make sure all the code examples in the Scaladoc `{{{ ... }}}` are consistent (compilable).