### PR TITLE
Add iterableWrites2 because iterableWrites is incompatible with Map[A, B]

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
@@ -428,11 +428,20 @@ sealed trait LowPriorityWrites extends EnvWrites {
 
   /**
    * Serializer for Iterable types.
+   *
+   * Deprecated due to incompatibility with non `_[_]` shapes, #368.
    */
-  implicit def iterableWrites[A, M[T] <: Iterable[T]](implicit w: Writes[A]): Writes[M[A]] = {
+  @deprecated("Use `iterableWrites2`", "2.8.1")
+  def iterableWrites[A, M[T] <: Iterable[T]](implicit w: Writes[A]): Writes[M[A]] =
+    iterableWrites2[A, M[A]]
+
+  /**
+   * Serializer for Iterable types.
+   */
+  implicit def iterableWrites2[A, I](implicit ev: I <:< Iterable[A], w: Writes[A]): Writes[I] = {
     // Use Iterable rather than Traversable, for 2.13 compat
 
-    Writes[M[A]] { as =>
+    Writes[I] { as =>
       val builder = mutable.ArrayBuilder.make[JsValue]
 
       as.foreach { a: A =>

--- a/play-json/shared/src/test/scala/play/api/libs/json/WritesSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/WritesSharedSpec.scala
@@ -60,6 +60,12 @@ class WritesSharedSpec extends WordSpec with MustMatchers {
     }
   }
 
+  "Iterable writes" should {
+    "write maps" in {
+      Json.toJson(Map(1 -> "one")).mustEqual(Json.arr(Json.arr(1, "one")))
+    }
+  }
+
   "Big integer Writes" should {
     "write as JsNumber" in {
       val jsNum = JsNumber(BigDecimal("123"))


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #368 

## Purpose

Add new implicit `iterableWrites2` with a signature that can work with arbitrary shapes.
Make old `iterableWrites` non-implicit to let new implicit work, but keep it as deprecated to preserve backward compatibility.

## Background Context

Took this approach because it worked for me :)

## References

None.