### PR TITLE
Introduce method `of` and `pure` specialized for `OWrites`

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
@@ -77,6 +77,13 @@ trait OWrites[A] extends Writes[A] {
 object OWrites extends PathWrites with ConstraintWrites {
   import play.api.libs.functional._
 
+  def of[A](implicit w: OWrites[A]): OWrites[A] = w
+
+  def pure[A](fixed: => A)(implicit wrs: OWrites[A]): OWrites[JsValue] =
+    OWrites[JsValue] { js =>
+      wrs.writes(fixed)
+    }
+
   /**
    * An `OWrites` merging the results of two separate `OWrites`.
    */


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Purpose

This change allows us to resolve an `OWrites[T]` via `OWrites.of[T]`.

## Background Context

I was trying to use `contramap` on an `OWrites[T]`:
```scala
OWrites.of[T].contramap[X](_.whatever)
```
Surpisingly, this led to an error later, since the caller expected an `OWrites[X]` but `OWrites.of` is simply inherited from `ConstraintWrites` and returns a `Writes`.
