### PR TITLE
Update PR template to fix CLA link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 # Pull Request Checklist
 
 * [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
-* [ ] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
+* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
 * [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
 * [ ] Have you added copyright headers to new files?
 * [ ] Have you updated the documentation?


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

The PR template currently links out to https://www.typesafe.com/contribute/cla which breaks with:

```
Websites prove their identity via certificates. Firefox does not trust this site 
because it uses a certificate that is not valid for www.typesafe.com. 

The certificate is only valid for the following names: repo.lightbend.com, demo.typesafe.com, info.typesafe.com, inform.typesafe.com, lightbend.com, media.lightbend.com, monitoring.lightbend.com, monitoring.typesafe.com, platform.lightbend.com, private-repo.lightbend.com, private-repo.typesafe.com, repo.scala-sbt.org, repo.typesafe.com, resources.lightbend.com, resources.typesafe.com, solutions.lightbend.com, support.typesafe.com, together.typesafe.com, typesafe.com

Error code: SSL_ERROR_BAD_CERT_DOMAIN
```

I assume that s/typesafe/lightbend/ is the right thing to do here...