### PR TITLE
Identity writes/reads

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
@@ -31,7 +31,12 @@ object JsValue {
 /**
  * Represents a Json null value.
  */
-case object JsNull extends JsValue
+case object JsNull extends JsValue {
+  implicit val reads: Reads[JsNull.type] = Reads[JsNull.type] {
+    case JsNull => JsSuccess(JsNull)
+    case _      => JsError("error.expected.null")
+  }
+}
 
 /**
  * Represents a Json boolean value.
@@ -215,4 +220,7 @@ object JsObject extends (Seq[(String, JsValue)] => JsObject) {
 
   /** An empty JSON object */
   def empty = JsObject(Seq.empty)
+
+  /** Identity writes */
+  implicit def writes: OWrites[JsObject] = OWrites[JsObject](identity)
 }

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
@@ -213,5 +213,6 @@ object JsObject extends (Seq[(String, JsValue)] => JsObject) {
    */
   def apply(fields: collection.Seq[(String, JsValue)]): JsObject = new JsObject(createFieldsMap(fields))
 
+  /** An empty JSON object */
   def empty = JsObject(Seq.empty)
 }

--- a/play-json/shared/src/test/scala/play/api/libs/json/ReadsSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/ReadsSharedSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class ReadsSharedSpec extends AnyWordSpec with Matchers {
+final class ReadsSharedSpec extends AnyWordSpec with Matchers {
   "Reads" should {
     "not repath the second result on flatMap" when {
       val aPath                 = JsPath \ "a"
@@ -225,6 +225,31 @@ class ReadsSharedSpec extends AnyWordSpec with Matchers {
         case _ => ()
       }
     }
+  }
+
+  "Identity reads" should {
+    def success[T <: JsValue](fixture: T)(implicit r: Reads[T], ct: scala.reflect.ClassTag[T]) =
+      s"be resolved for $fixture as ${ct.runtimeClass.getSimpleName}" in {
+        r.reads(fixture).mustEqual(JsSuccess(fixture))
+      }
+
+    success[JsArray](Json.arr("foo", 2))
+    success[JsValue](Json.arr("foo", 2))
+
+    success[JsBoolean](JsFalse)
+    success[JsValue](JsTrue)
+
+    success[JsNull.type](JsNull)
+    success[JsValue](JsNull)
+
+    success[JsNumber](JsNumber(1))
+    success[JsValue](JsNumber(1))
+
+    success[JsObject](JsObject(Map("foo" -> JsNumber(1))))
+    success[JsValue](JsObject(Map("foo"  -> JsNumber(1))))
+
+    success[JsString](JsString("foo"))
+    success[JsValue](JsString("foo"))
   }
 
   // ---


### PR DESCRIPTION
Make sure the `JsValue` types are provided instances of the `{,O}Writes` and `Reads` typeclasses.

```scala
def foo[T: OWrites](T) = ???

foo(Json.obj("bar" -> 1))
```

See: [error before](https://travis-ci.com/github/playframework/play-json/jobs/320427844#L417)

```
Errors 0, Passed 1

[error] /home/travis/build/playframework/play-json/play-json/shared/src/test/scala/play/api/libs/json/ReadsSharedSpec.scala:242:25: No Json deserializer found for type play.api.libs.json.JsNull.type. Try to implement an implicit Reads or Format for this type.

...

[error] /home/travis/build/playframework/play-json/play-json/shared/src/test/scala/play/api/libs/json/WritesSharedSpec.scala:126:31: No Json serializer as JsObject found for type play.api.libs.json.JsObject. Try to implement an implicit OWrites or OFormat for this type.
```