### PR TITLE
Keep Scala.js on 1.0.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -5,6 +5,9 @@ updates.pin  = [
   // https://github.com/akka/akka/blob/master/project/Dependencies.scala#L24
   { groupId = "com.fasterxml.jackson.core", version = "2.10." }
   { groupId = "com.fasterxml.jackson.datatype", version = "2.10." }
+  // "It is not forward binary compatible with 1.0.x: libraries compiled with 1.1.0 cannot be used with 1.0.x."
+  // https://users.scala-lang.org/t/announcing-scala-js-1-1-0/6053/3?u=sjrd
+  { groupId = "org.scala-js", artifactId= "sbt-scalajs", version = "1.0." }
 ]
 
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,8 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.7.0")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.1")
+// "It is not forward binary compatible with 1.0.x: libraries compiled with 1.1.0 cannot be used with 1.0.x."
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 


### PR DESCRIPTION
As discussed in https://github.com/playframework/play-json/pull/454#pullrequestreview-417289779 Scala.js
should stay on 1.0.x to make Play JSON work with both Scala.js 1.0.x and 1.1.x.

Reverts #485