### PR TITLE
Writes narrow

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
@@ -34,6 +34,11 @@ trait Writes[A] { self =>
   def contramap[B](f: B => A): Writes[B] = Writes[B](b => self.writes(f(b)))
 
   /**
+   * Narrows to any `B` super-type of `A`.
+   */
+  def narrow[B <: A]: Writes[B] = this.asInstanceOf[Writes[B]]
+
+  /**
    * Transforms the resulting [[JsValue]] using transformer function.
    */
   def transform(transformer: JsValue => JsValue): Writes[A] = Writes[A] { a =>
@@ -72,6 +77,8 @@ trait OWrites[A] extends Writes[A] {
 
   override def contramap[B](f: B => A): OWrites[B] =
     OWrites[B](b => this.writes(f(b)))
+
+  override def narrow[B <: A]: OWrites[B] = this.asInstanceOf[OWrites[B]]
 }
 
 object OWrites extends PathWrites with ConstraintWrites {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

Considering types `A` and `B`, if `A <: B` and `Writes[A]` (or `OWrites[A]`) is provided, then be able to explicitly narrow to `Writes[B]`.

```scala
trait Foo {
  def bar: String
}

class Lorem(val bar: String) extends Foo

val parentWrites: OWrites[Foo] = OWrites[Foo] { foo =>
  Json.obj("bar" -> foo.bar)
}

val narrowedWrites: OWrites[Lorem] = parentWrites.narrow[Lorem]

narrowedWrites.writes(new Lorem("ipsum")) // => Json.obj("bar" -> "ipsum")
```