### PR TITLE
JsObject should return immutable collections (play-json 2.8/ scala 2.13) #388

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -68,7 +68,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
     case JsDefined(x) =>
       x match {
         case arr: JsObject =>
-          arr.value.get(fieldName) match {
+          arr.valueMap.get(fieldName) match {
             case Some(x) => x
             case None    => throw new NoSuchElementException(String.valueOf(fieldName))
           }
@@ -101,7 +101,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    */
   def \(fieldName: String): JsLookupResult = result match {
     case JsDefined(obj @ JsObject(_)) =>
-      obj.value
+      obj.valueMap
         .get(fieldName)
         .map(JsDefined.apply)
         .getOrElse(JsUndefined(s"'$fieldName' is undefined on object: $obj"))
@@ -117,7 +117,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    */
   def \\(fieldName: String): collection.Seq[JsValue] = result match {
     case JsDefined(obj: JsObject) =>
-      obj.value.foldLeft(Seq[JsValue]())((o, pair) =>
+      obj.valueMap.foldLeft(Seq[JsValue]())((o, pair) =>
         pair match {
           case (key, value) if key == fieldName => o ++ (value +: (value \\ fieldName))
           case (_, value)                       => o ++ (value \\ fieldName)

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
@@ -134,7 +134,16 @@ case class JsObject(
   /**
    * The value of this JsObject as an immutable map.
    */
+  @deprecated("Use `valueMap` instead", "2.9.3")
   lazy val value: Map[String, JsValue] = underlying match {
+    case m: immutable.Map[String, JsValue] => m
+    case m                                 => m.toMap
+  }
+
+  /**
+   * The value of this JsObject as an immutable map.
+   */
+  lazy val valueMap: immutable.Map[String, JsValue] = underlying match {
     case m: immutable.Map[String, JsValue] => m
     case m                                 => m.toMap
   }
@@ -142,7 +151,7 @@ case class JsObject(
   /**
    * Return all fields as a set
    */
-  def fieldSet: Set[(String, JsValue)] = fields.toSet
+  def fieldSet: immutable.Set[(String, JsValue)] = fields.toSet
 
   /**
    * Return all keys


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes [#388](https://github.com/playframework/play-json/issues/388)

## Purpose

What does this PR do?
Change JsValue.fieldSet return type from Set[(String, JsValue)] to immutable.Set[(String, JsValue)] and deprecate JsValue.value: Map[String, JsValue] in favor of valueMap: immutable.Map[String, JsValue]

## Background Context

Suggestion from @octonato on [#388](https://github.com/playframework/play-json/issues/388)

## References

[#388](https://github.com/playframework/play-json/issues/388)
