### PR TITLE
Out with 3.0.0-M3, in with Scala 3.0.0-RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,13 +44,13 @@ jobs:
     - name: "Run tests with Scala 3 and AdoptOpenJDK 8"
       script: scripts/test-code.sh
       env:
-        - SCALA_VERSION=3.0.0-M3
+        - SCALA_VERSION=3.0.0-RC1
         - TRAVIS_JDK=8
 
     - name: "Run tests with Scala 3 and AdoptOpenJDK 8"
       script: scripts/test-code.sh
       env:
-        - SCALA_VERSION=3.0.0-RC1
+        - SCALA_VERSION=3.0.0-RC2
         - TRAVIS_JDK=8
 
     - stage: publish

--- a/play-json/js/src/main/scala/StaticBinding.scala
+++ b/play-json/js/src/main/scala/StaticBinding.scala
@@ -108,7 +108,7 @@ object StaticBinding {
   }
 
   @inline private def fromString(s: String, escapeNonASCII: Boolean): String =
-    if (!escapeNonASCII) JSON.stringify(s) else escapeStr(JSON.stringify(s))
+    if (!escapeNonASCII) JSON.stringify(s, null) else escapeStr(JSON.stringify(s, null))
 
   private def anyToJsValue(raw: Any): JsValue = raw match {
     case null           => JsNull

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,5 +2,5 @@ object Dependencies {
   // scalaVersion needs to be kept in sync with travis-ci
   val Scala212 = "2.12.13"
   val Scala213 = "2.13.5"
-  val Scala3   = Seq("3.0.0-M3", "3.0.0-RC1")
+  val Scala3   = Seq("3.0.0-RC1", "3.0.0-RC2")
 }


### PR DESCRIPTION
In spirit of supporting last two version of Scala 3.0.0, here is bump to `RC2` while dropping `M3`.

Helping with https://github.com/http4s/http4s/pull/4681