### PR TITLE
rename master to main, matching new GitHub default

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ stages:
   - name: check
   - name: test
   - name: publish
-    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+    if: ((branch = main AND type = push) OR (tag IS present)) AND NOT fork
 
 cache:
   directories:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,13 @@
 # Releasing
 
-This is released from the `master` branch from `2.9.0` forward. Unless an older version needs patching, then it must be released from the maintenance branch, for instance `2.8.x` branch. If there is no maintenance branch for the release that needs patching, create it from the tag.
+This is released from the `main` branch from `2.9.0` forward. Unless an older version needs patching, then it must be released from the maintenance branch, for instance `2.8.x` branch. If there is no maintenance branch for the release that needs patching, create it from the tag.
 
 ## Cutting the release
 
 ### Requires contributor access
 
 - Check the [draft release notes](https://github.com/playframework/play-json/releases) to see if everything is there
-- Wait until [master build finished](https://travis-ci.com/github/playframework/play-json/builds) after merging the last PR
+- Wait until [main build finished](https://travis-ci.com/github/playframework/play-json/builds) after merging the last PR
 - Update the [draft release](https://github.com/playframework/play-json/releases) with the next tag version (eg. `2.9.0`), title and release description
 - Check that Travis CI release build has executed successfully (Travis will start a [CI build](https://travis-ci.com/github/playframework/play-json/builds) for the new tag and publish artifacts to Bintray)
 


### PR DESCRIPTION
hey, other maintainers: I don't know how intertwined the various playframework/* repos are — is there anything else somewhere that would need to be updated?

note that I have not actually renamed the branch yet — I'll go ahead with merging this and renaming on Monday, unless someone tells me I shouldn't