### PR TITLE
Travis-CI: fix no-longer-valid Jabba URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ git:
   depth: false # Avoid sbt-dynver not seeing the tag
 
 before_install:
-  - curl -Ls https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
+  - curl -Ls https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | JABBA_VERSION=0.11.2 bash && . ~/.jabba/jabba.sh
   # Travis-CI has (as of March 2021, anyway) an outdated sbt-extras version,
   # so overwrite it with a March 2021 version that works with sbt 1.4.8+
   - |


### PR DESCRIPTION
as per https://github.com/shyiko/jabba/issues/784#issuecomment-812105087

it would also be possible to ask for the `install.sh` on `master`, but I like this fix better because it keeps the build reproducible
