### PR TITLE
Use the correct value for sonatypeProfileName

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ jobs:
         - SCALA_VERSION=3.0.0
         - TRAVIS_JDK=8
 
-    - stage: publish
-      name: "Publish artifacts to Sonatype"
+    - stage: release
+      name: "Release artifacts to Sonatype"
       script: sbt ci-release
       env:
         - TRAVIS_JDK=11

--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,8 @@ lazy val commonSettings = Def.settings(
   Compile / doc / scalacOptions ++= Seq(
     // Work around 2.12 bug which prevents javadoc in nested java classes from compiling.
     "-no-java-comments",
-  )
+  ),
+  sonatypeProfileName := "com.typesafe"
 )
 
 lazy val root = project


### PR DESCRIPTION
`com.typesafe` is the correct value for Play projects. This re-adds the setting
that was before defined in interplay.

References #612.
