### PR TITLE
fix warning in StaticBinding

### DIFF
--- a/play-json/js/src/main/scala/StaticBinding.scala
+++ b/play-json/js/src/main/scala/StaticBinding.scala
@@ -21,7 +21,7 @@ object StaticBinding {
 
     try {
       in = new java.io.InputStreamReader(stream, "UTF-8")
-      val acc = StringBuilder.newBuilder
+      val acc = new StringBuilder()
       val buf = Array.ofDim[Char](1024)
 
       @annotation.tailrec


### PR DESCRIPTION

# Pull Request Checklist


* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes warning

## Purpose



## Background Context


> [warn] /home/travis/build/playframework/play-json/play-json/js/src/main/scala/StaticBinding.scala:24:31: method newBuilder in object StringBuilder is deprecated (since 2.13.0): Use `new StringBuilder()` instead of `StringBuilder.newBuilder`
> [warn]       val acc = StringBuilder.newBuilder
> [warn]                               ^



## References


