### PR TITLE
Upgrade jackson to latest compatible with play 2.8.x framework

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,12 +23,12 @@ val specs2 = Seq(
   "org.specs2" %% "specs2-junit" % "4.8.1" % Test,
 )
 
-val jacksonDatabindVersion = "2.10.1"
+val jacksonDatabindVersion = "2.11.4"
 val jacksonDatabind = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 )
 
-val jacksonVersion = "2.10.1"
+val jacksonVersion = "2.11.4"
 val jacksons = Seq(
   "com.fasterxml.jackson.core"     % "jackson-core",
   "com.fasterxml.jackson.core"     % "jackson-annotations",


### PR DESCRIPTION
There is high-level vulnerability reported for [jackson 2.10.x](https://snyk.io/vuln/maven:com.fasterxml.jackson.core%3Ajackson-databind) which this PR intends to address.

Play-framework 2.8.8 already pulls in Jackson library version 2.11.4 on top of play-json 2.8.1 (overrides jackson version in the application), so a testament that play-json 2.8.1 is already compatible with Jackson 2.11.4.