### PR TITLE
Better handle String hashCode collisions in JsLookup

### DIFF
--- a/benchmarks/src/main/scala/play/api/libs/json/JsonParsing_01_ParseManyFields.scala
+++ b/benchmarks/src/main/scala/play/api/libs/json/JsonParsing_01_ParseManyFields.scala
@@ -6,12 +6,20 @@ package play.api.libs.json
 
 import org.openjdk.jmh.annotations._
 
+/**
+  * @see https://github.com/playframework/play-json/pull/193
+  */
 @State(Scope.Benchmark)
 class JsonParsing_01_ParseManyFields {
   @Param(Array("10", "100", "1000", "10000", "100000"))
   var n: Int = 100
 
   var stringToParse: String = _
+
+  case class Example(s: String)
+  object Example {
+    implicit val reads = Json.reads[Example]
+  }
 
   @Setup
   def setup(): Unit = {
@@ -21,7 +29,22 @@ class JsonParsing_01_ParseManyFields {
   }
 
   @Benchmark
-  def parseObject(): Unit = {
+  def parseObject(): JsValue = {
     Json.parse(stringToParse)
+  }
+
+  @Benchmark
+  def parseObjectAs(): Example = {
+    Json.parse(stringToParse).as[Example]
+  }
+
+  @Benchmark
+  def parseObjectLookup(): JsValue = {
+    (Json.parse(stringToParse) \ "s").as[JsString]
+  }
+
+  @Benchmark
+  def parseObjectValue(): Option[JsValue] = {
+    Json.parse(stringToParse).as[JsObject].value.get("s")
   }
 }

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -68,7 +68,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
     case JsDefined(x) =>
       x match {
         case arr: JsObject =>
-          arr.value.get(fieldName) match {
+          arr.underlying.get(fieldName) match {
             case Some(x) => x
             case None    => throw new NoSuchElementException(String.valueOf(fieldName))
           }
@@ -101,7 +101,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    */
   def \(fieldName: String): JsLookupResult = result match {
     case JsDefined(obj @ JsObject(_)) =>
-      obj.value
+      obj.underlying
         .get(fieldName)
         .map(JsDefined.apply)
         .getOrElse(JsUndefined(s"'$fieldName' is undefined on object: $obj"))
@@ -117,7 +117,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    */
   def \\(fieldName: String): collection.Seq[JsValue] = result match {
     case JsDefined(obj: JsObject) =>
-      obj.value.foldLeft(Seq[JsValue]())((o, pair) =>
+      obj.underlying.foldLeft(Seq[JsValue]())((o, pair) =>
         pair match {
           case (key, value) if key == fieldName => o ++ (value +: (value \\ fieldName))
           case (_, value)                       => o ++ (value \\ fieldName)


### PR DESCRIPTION
#186 is still exploitable when `JsLookup` is used (`jsObject \ "foo"`) or `jsObject.value` is called directly.

Thankfully, the `Reads` macro doesn't use either of these approaches. Instead, it extracts fields from `jsObject.underlying` (typically a `java.util.LinkedHashMap`). If this approach is good enough for the macro, it seems to make sense to do for `JsLookup` as well.

`jsObject.value` is still vulnerable, but there are no remaining references to it internally after this PR.

Before:
```
[info] Benchmark                                           (n)   Mode  Cnt    Score    Error  Units
[info] JsonParsing_01_ParseManyFields.parseObject        10000  thrpt    3  170.811 ± 24.671  ops/s
[info] JsonParsing_01_ParseManyFields.parseObjectAs      10000  thrpt    3  163.436 ± 13.332  ops/s
[info] JsonParsing_01_ParseManyFields.parseObjectLookup  10000  thrpt    3    1.462 ±  0.077  ops/s
[info] JsonParsing_01_ParseManyFields.parseObjectValue   10000  thrpt    3    1.452 ±  0.144  ops/s
```

After:
```
[info] Benchmark                                           (n)   Mode  Cnt    Score    Error  Units
[info] JsonParsing_01_ParseManyFields.parseObject        10000  thrpt    3  174.182 ±  18.880  ops/s
[info] JsonParsing_01_ParseManyFields.parseObjectAs      10000  thrpt    3  158.034 ±  44.744  ops/s
[info] JsonParsing_01_ParseManyFields.parseObjectLookup  10000  thrpt    3  167.274 ±  54.709  ops/s
[info] JsonParsing_01_ParseManyFields.parseObjectValue   10000  thrpt    3    1.451 ±   0.111  ops/s
```

Relates to #193. @gmethvin @marcospereira 