### PR TITLE
Change `jsObject.value` to return the `underlying: Map`

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
@@ -132,12 +132,9 @@ case class JsObject(
   lazy val fields: collection.Seq[(String, JsValue)] = underlying.toSeq
 
   /**
-   * The value of this JsObject as an immutable map.
+   * The value of this JsObject as a map.
    */
-  lazy val value: Map[String, JsValue] = underlying match {
-    case m: immutable.Map[String, JsValue] => m
-    case m                                 => m.toMap
-  }
+  def value: Map[String, JsValue] = underlying
 
   /**
    * Return all fields as a set


### PR DESCRIPTION
After #674, `jsObject.value` would never be used internally (which is great for heap usage and to avoid rehashing), but it's still vulnerable to #186. This PR changes `jsObject.value` to return the `underlying` Map directly.

The scaladoc says "The value of this JsObject as an _immutable_ map", but the type signature is only `scala.collection.Map`. Anyone requiring a `scala.collection.immutable.Map` would need to call `.toMap` anyway or do an `.asInstanceOf[s.c.i.Map]`.

If we just return `m` directly and change remove "immutable" from the scaladoc, it would do good things for memory footprint and throughput.

Before:
```
[info] Benchmark                                           (n)   Mode  Cnt    Score    Error  Units
[info] JsonParsing_01_ParseManyFields.parseObjectValue   10000  thrpt    3    1.452 ±  0.144  ops/s
```

TreeMap (#675):
```
[info] Benchmark                                          (n)   Mode  Cnt    Score    Error  Units
[info] JsonParsing_01_ParseManyFields.parseObjectValue  10000  thrpt    3  140.802 ± 10.599  ops/s
```

This PR:
```
[info] Benchmark                                          (n)   Mode  Cnt    Score    Error  Units
[info] JsonParsing_01_ParseManyFields.parseObjectValue  10000  thrpt    3  167.452 ± 37.356  ops/s
```

One minor caveat: this would shift the responsibility for handling hashCode collisions onto users, but this method isn't suggested usage and we didn't handle them previously anyway.

This is an alternative to #675, although there's active discussion happening in https://github.com/playframework/play-json/pull/675#discussion_r754626746.

@gmethvin 