### PR TITLE
[2.8.x] update sonatype profile name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ resolvers ++= DefaultOptions.resolvers(snapshot = true)
 playBuildRepoName in ThisBuild := "play-json"
 publishTo in ThisBuild := sonatypePublishToBundle.value
 
+
 val specs2 = Seq(
   "org.specs2" %% "specs2-core"  % "4.8.1" % Test,
   "org.specs2" %% "specs2-junit" % "4.8.1" % Test,
@@ -124,7 +125,8 @@ lazy val commonSettings = Def.settings(
   scalacOptions in (Compile, doc) ++= Seq(
     // Work around 2.12 bug which prevents javadoc in nested java classes from compiling.
     "-no-java-comments",
-  )
+  ), 
+  sonatypeProfileName := "com.typesafe.play"
 )
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ resolvers ++= DefaultOptions.resolvers(snapshot = true)
 playBuildRepoName in ThisBuild := "play-json"
 publishTo in ThisBuild := sonatypePublishToBundle.value
 
-
 val specs2 = Seq(
   "org.specs2" %% "specs2-core"  % "4.8.1" % Test,
   "org.specs2" %% "specs2-junit" % "4.8.1" % Test,
@@ -125,7 +124,7 @@ lazy val commonSettings = Def.settings(
   scalacOptions in (Compile, doc) ++= Seq(
     // Work around 2.12 bug which prevents javadoc in nested java classes from compiling.
     "-no-java-comments",
-  ), 
+  ),
   sonatypeProfileName := "com.typesafe.play"
 )
 


### PR DESCRIPTION
Updates the sonatype profile name to use `com.typesafe.play` org. 

It's not possible (yet) to release play-json from the 2.8.x using tagging in GitHub, but with this change we can already release from local machine.