### PR TITLE
Optimize `JsObject.equals()`/`hashCode()`

### DIFF
--- a/benchmarks/src/main/scala/play/api/libs/json/JsObjectBench.scala
+++ b/benchmarks/src/main/scala/play/api/libs/json/JsObjectBench.scala
@@ -1,0 +1,56 @@
+package play.api.libs.json
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * ==Quick Run==
+ * benchmarks / Jmh / run .*JsObjectBench
+ *
+ * ==Profile with Flight Recorder==
+ * benchmarks / Jmh / run -prof jfr .*JsObjectBench
+ *
+ * ==Jmh Visualizer Report==
+ * benchmarks / Jmh / run -f5 -prof gc -rf json -rff JsObjectBench-results.json .*JsObjectBench
+ *
+ * ==Sample Results==
+ * {{{
+ * Benchmark                    (size)   Mode  Cnt       Score       Error   Units
+ * JsObjectBench.oEqualsCopy        15  thrpt    5    4386.757 ±   124.675  ops/ms
+ * JsObjectBench.oEqualsEq          15  thrpt    5  430769.750 ± 43891.912  ops/ms
+ * JsObjectBench.oEqualsNe          15  thrpt    5  321636.207 ± 23899.623  ops/ms
+ * JsObjectBench.oHashCodeWarm      15  thrpt    5    4024.849 ±   276.276  ops/ms
+ * }}}
+ *
+ * @see https://github.com/ktoso/sbt-jmh
+ */
+@Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+  jvmArgsAppend =
+    Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:-BackgroundCompilation", "-XX:-TieredCompilation"),
+  value = 1
+)
+class JsObjectBench {
+
+  @Param(Array("1", "15"))
+  var size: Int                       = _
+  private var jsObject: JsObject      = _
+  private var jsObjectClone: JsObject = _
+  private var jsObjectCopy: JsObject  = _
+
+  @Setup def setup(): Unit = {
+    jsObject = JsObject(0.until(size).map(i => i.toString -> JsTrue))
+    jsObjectClone = JsObject(jsObject.underlying)
+    jsObjectCopy = Json.parse(jsObject.toString).as[JsObject]
+  }
+
+  @Benchmark def oEqualsEq     = jsObject == jsObject
+  @Benchmark def oEqualsNe     = jsObject == jsObjectClone
+  @Benchmark def oEqualsCopy   = jsObject == jsObjectCopy
+  @Benchmark def oHashCodeWarm = jsObject.hashCode()
+}

--- a/play-json/jvm/src/test/scala-3/play/api/libs/json/JsonMemoryFootprintSpec.scala
+++ b/play-json/jvm/src/test/scala-3/play/api/libs/json/JsonMemoryFootprintSpec.scala
@@ -12,8 +12,8 @@ class JsonMemoryFootprintSpec extends AnyFreeSpec {
 
   "Json.parse" - {
     "obj0" in assertSizes("""{}""", 32, 32)
-    "obj1" in assertSizes("""{"1":true}""", 168, 232)
-    "obj4" in assertSizes("""{"1":true,"2":true,"3":true,"4":true}""", 312, 520)
+    "obj1" in assertSizes("""{"1":true}""", 168, 184)
+    "obj4" in assertSizes("""{"1":true,"2":true,"3":true,"4":true}""", 312, 328)
 
     "arr0" in assertSizes("""[]""", 120, 120)
     "arr1" in assertSizes("""[true]""", 120, 120)
@@ -44,7 +44,7 @@ class JsonMemoryFootprintSpec extends AnyFreeSpec {
     def arr1KB(elem: String, targetSize: Int = 1000): String =
       Iterator.continually(elem).take(targetSize / (elem.length + 1)).mkString("[", ",", "]")
     "obj0" in assertSizes(arr1KB("{}"), 12760, 12760)
-    "obj1" in assertSizes(arr1KB("""{"a":6}"""), 31568, 39568)
+    "obj1" in assertSizes(arr1KB("""{"a":6}"""), 31568, 33568)
     "nums" in assertSizes(arr1KB("6"), 42104, 42104)
     "arr0" in assertSizes(arr1KB("[]"), 42064, 42064)
     "arr1" in assertSizes(arr1KB("[6]"), 51080, 51080)


### PR DESCRIPTION
## Summary
For `JsObject.equals()`/`hashCode()`:
- improves runtime by avoiding making two copies of the underlying data
- improves memory footprint by avoiding holding `lazy val fields: collection.Seq[(String, JsValue)]` after the computation is performed.
- Benchmark: [jmh results](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/htmldoug/6ebb5f3f169e35535a99e2d198c9153d/raw/f8f1a3b905de98829e607ad41fe8ffa936ffd6c8/report-before.json,https://gist.githubusercontent.com/htmldoug/6ebb5f3f169e35535a99e2d198c9153d/raw/f8f1a3b905de98829e607ad41fe8ffa936ffd6c8/report-after.json)