### PR TITLE
Use regexp for Mergify conditions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,12 +5,12 @@ queue_rules:
       - check-success=Check / Code Style
       - check-success=Check / Binary Compatibility
       - check-success=Check / Docs
-      - check-success=Check / Tests (Scala 2.12.15 & JDK 11)
-      - check-success=Check / Tests (Scala 2.13.8 & JDK 11)
-      - check-success=Check / Tests (Scala 3.0.2 & JDK 11)
-      - check-success=Check / Tests (Scala 2.12.15 & JDK 8)
-      - check-success=Check / Tests (Scala 2.13.8 & JDK 8)
-      - check-success=Check / Tests (Scala 3.0.2 & JDK 8)
+      - check-success~=^Check / Tests \(Scala 2\.12\.(\d+) & JDK 11\)$
+      - check-success~=^Check / Tests \(Scala 2\.13\.(\d+) & JDK 11\)$
+      - check-success~=^Check / Tests \(Scala 3\.(\d+)\.(\d+) & JDK 11\)$
+      - check-success~=^Check / Tests \(Scala 2\.12\.(\d+) & JDK 8\)$
+      - check-success~=^Check / Tests \(Scala 2\.13\.(\d+) & JDK 8\)$
+      - check-success~=^Check / Tests \(Scala 3\.(\d+)\.(\d+) & JDK 8\)$
 
 pull_request_rules:
   - name: Merge PRs that are ready
@@ -18,12 +18,12 @@ pull_request_rules:
       - check-success=Check / Code Style
       - check-success=Check / Binary Compatibility
       - check-success=Check / Docs
-      - check-success=Check / Tests (Scala 2.12.15 & JDK 11)
-      - check-success=Check / Tests (Scala 2.13.8 & JDK 11)
-      - check-success=Check / Tests (Scala 3.0.2 & JDK 11)
-      - check-success=Check / Tests (Scala 2.12.15 & JDK 8)
-      - check-success=Check / Tests (Scala 2.13.8 & JDK 8)
-      - check-success=Check / Tests (Scala 3.0.2 & JDK 8)
+      - check-success~=^Check / Tests \(Scala 2\.12\.(\d+) & JDK 11\)$
+      - check-success~=^Check / Tests \(Scala 2\.13\.(\d+) & JDK 11\)$
+      - check-success~=^Check / Tests \(Scala 3\.(\d+)\.(\d+) & JDK 11\)$
+      - check-success~=^Check / Tests \(Scala 2\.12\.(\d+) & JDK 8\)$
+      - check-success~=^Check / Tests \(Scala 2\.13\.(\d+) & JDK 8\)$
+      - check-success~=^Check / Tests \(Scala 3\.(\d+)\.(\d+) & JDK 8\)$
       - status-success=typesafe-cla-validator
       - "#approved-reviews-by>=1"
       - "#review-requested=0"


### PR DESCRIPTION
More details in [Mergify docs](https://docs.mergify.com/configuration/#regular-expressions).
I checked that in [regex101](https://regex101.com).
Now Mergify should be more loyal for updating patch versions of Scala. 🤞 