### PR TITLE
Remove JsObject lazy vals

### DIFF
--- a/play-json/jvm/src/test/scala-3/play/api/libs/json/JsonMemoryFootprintSpec.scala
+++ b/play-json/jvm/src/test/scala-3/play/api/libs/json/JsonMemoryFootprintSpec.scala
@@ -11,9 +11,9 @@ import scala.util.chaining._
 class JsonMemoryFootprintSpec extends AnyFreeSpec {
 
   "Json.parse" - {
-    "obj0" in assertSizes("""{}""", 32, 32)
-    "obj1" in assertSizes("""{"1":true}""", 168, 184)
-    "obj4" in assertSizes("""{"1":true,"2":true,"3":true,"4":true}""", 312, 328)
+    "obj0" in assertSizes("""{}""", 16, 16)
+    "obj1" in assertSizes("""{"1":true}""", 152, 168)
+    "obj4" in assertSizes("""{"1":true,"2":true,"3":true,"4":true}""", 296, 312)
 
     "arr0" in assertSizes("""[]""", 120, 120)
     "arr1" in assertSizes("""[true]""", 120, 120)
@@ -32,19 +32,19 @@ class JsonMemoryFootprintSpec extends AnyFreeSpec {
 
   "JsObject" - {
     def obj(json: String) = Json.parse(json).as[JsObject]
-    "obj0 ++ obj0" in assertSize(obj("{}") ++ obj("{}"), 32)
-    "obj0 ++ obj1" in assertSize(obj("{}") ++ obj("""{"1":true}"""), 168)
-    "obj1 ++ obj0" in assertSize(obj("""{"1":true}""") ++ obj("""{}"""), 168)
+    "obj0 ++ obj0" in assertSize(obj("{}") ++ obj("{}"), 16)
+    "obj0 ++ obj1" in assertSize(obj("{}") ++ obj("""{"1":true}"""), 152)
+    "obj1 ++ obj0" in assertSize(obj("""{"1":true}""") ++ obj("""{}"""), 152)
 
-    "obj1.value" in assertSize(obj("""{"1":true}""").tap(_.value), 168)
+    "obj1.value" in assertSize(obj("""{"1":true}""").tap(_.value), 152)
   }
 
   "malicious" - {
     // if we pack data into ~1KB of input, how much memory amplification can we achieve?
     def arr1KB(elem: String, targetSize: Int = 1000): String =
       Iterator.continually(elem).take(targetSize / (elem.length + 1)).mkString("[", ",", "]")
-    "obj0" in assertSizes(arr1KB("{}"), 12760, 12760)
-    "obj1" in assertSizes(arr1KB("""{"a":6}"""), 31568, 33568)
+    "obj0" in assertSizes(arr1KB("{}"), 7432, 7432)
+    "obj1" in assertSizes(arr1KB("""{"a":6}"""), 29568, 31568)
     "nums" in assertSizes(arr1KB("6"), 42104, 42104)
     "arr0" in assertSizes(arr1KB("[]"), 42064, 42064)
     "arr1" in assertSizes(arr1KB("[6]"), 51080, 51080)

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
@@ -130,12 +130,12 @@ case class JsObject(
   /**
    * The fields of this JsObject in the order passed to the constructor
    */
-  lazy val fields: collection.Seq[(String, JsValue)] = underlying.toSeq
+  def fields: collection.Seq[(String, JsValue)] = underlying.toSeq
 
   /**
    * The value of this JsObject as an immutable map.
    */
-  lazy val value: Map[String, JsValue] = underlying match {
+  def value: Map[String, JsValue] = underlying match {
     case m: immutable.Map[String, JsValue] => m
     case m                                 => JsObject.createFieldsMap(m)
   }
@@ -143,7 +143,7 @@ case class JsObject(
   /**
    * Return all fields as a set
    */
-  def fieldSet: Set[(String, JsValue)] = fields.toSet
+  def fieldSet: Set[(String, JsValue)] = underlying.toSet
 
   /**
    * Return all keys


### PR DESCRIPTION
## Purpose

Reduce memory footprint by removing the (now unnecessary) lazy vals from `JsObject`.

## Background Context

Many of our production OOME heap dumps show `JsValue` consuming the majority of memory. I've seen scenarios where there are either too many objects (batching, parallelism), unexpectedly large objects (services returning unwanted data), or both. Regardless of other possible mitigations, it would be nice to reduce the memory footprint of `JsValue`.

In my previous PRs, I migrated most remaining internal usage off of the two lazy vals in JsObject.

- `lazy val value: Map[String, JsValue]` is now completely avoided, and `JsObject` provides an immutable underlying Map by default.
    - #674
    - #675
- `lazy val fields: Seq[(String, JsValue)]` - is no longer used for hashCode/equals, and the last remaining uses don't seem to benefit from having an additional memoized `Seq` floating around.
    - #692

## Caveats
The only drawbacks I can think of are in situations:
- if users explicitly stuff a truly `mutable.Map` into `JsObject`, in which case, they can restore the memoization of `value` (which isn't used internally anyway) by wrapping it in an immutable/unmodifiable wrapper.
- if users are reading `fields` (no longer used internally) more than once, but it's difficult to think of use cases for this. If desired, `override val fields = super.fields`.

While these (rare?) situations can be mitigated, the memory footprint of `JsObject` cannot be fixed in user space.

## Benefits
- Memory footprint of `JsObject`: 32 bytes => 16 bytes
    - better OOME tolerance
    - reduced GC pressure
- lazy val initialization check on `value` is gone which usually results in a ~5% improvement on access

### ClassLayout
```scala
ClassLayout.parseClass(classOf[JsObject]).toPrintable
```

#### Before:
```
play.api.libs.json.JsObject object internals:
OFF  SZ                   TYPE DESCRIPTION               VALUE
  0   8                        (object header: mark)     N/A
  8   4                        (object header: class)    N/A
 12   1                   byte JsObject.bitmap$0         N/A
 13   3                        (alignment/padding gap)   
 16   4   scala.collection.Seq JsObject.fields           N/A
 20   4   scala.collection.Map JsObject.value            N/A
 24   4   scala.collection.Map JsObject.underlying       N/A
 28   4                        (object alignment gap)    
Instance size: 32 bytes
Space losses: 3 bytes internal + 4 bytes external = 7 bytes total
```

#### After:
```
play.api.libs.json.JsObject object internals:
OFF  SZ                   TYPE DESCRIPTION               VALUE
  0   8                        (object header: mark)     N/A
  8   4                        (object header: class)    N/A
 12   4   scala.collection.Map JsObject.underlying       N/A
Instance size: 16 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```
