### PR TITLE
Jackson 2.13

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,10 +1,6 @@
 pullRequests.frequency = "@weekly"
 
 updates.pin  = [
-  // Play JSON should follow the Jackson version in Akka to avoid conflicts in Playframework
-  // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L24
-  { groupId = "com.fasterxml.jackson.core", version = "2.11." }
-  { groupId = "com.fasterxml.jackson.datatype", version = "2.11." }
 ]
 
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,8 @@ def specs2(scalaVersion: String) =
     ("org.specs2" %% s"specs2-$n" % "4.14.1").cross(CrossVersion.for3Use2_13) % Test
   }
 
-val jacksonVersion         = "2.11.4"
-val jacksonDatabindVersion = jacksonVersion
+val jacksonVersion         = "2.13.2"
+val jacksonDatabindVersion = "2.13.2.2"
 
 val jacksonDatabind = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion


### PR DESCRIPTION
So akka is very conservative about upgrading jackson, because they do not want to break any existing apps.
However, based on these comments I assume akka itself will should work just fine with latest jackson since it "do[es]n't rely on any of the parts that changed":
* https://github.com/akka/akka/issues/31097#issuecomment-1024872663
* https://github.com/akka/akka/issues/31282#issuecomment-1087439343
* https://github.com/akka/akka/issues/31237#issuecomment-1064288737

So I suggest, if everything works out and CI agrees to finally upgrade jackson in play-json and play itself to the latest version for the next major release.