### PR TITLE
Scala Steward should ignore Jackson modules except `jackson-core`

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,3 +4,10 @@ updates.pin  = [
 ]
 
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
+
+updates.ignore = [
+  // these will get updated along with jackson-core, so no need to update them separately
+  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-annotations" }
+  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" }
+  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jsr310" }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -21,12 +21,12 @@ def specs2(scalaVersion: String) =
     ("org.specs2" %% s"specs2-$n" % "4.15.0") % Test
   }
 
-val jacksonVersion         = "2.13.3"
 val jacksonDatabindVersion = "2.13.3"
-
 val jacksonDatabind = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 )
+
+val jacksonVersion = "2.13.3"
 val jacksons = Seq(
   "com.fasterxml.jackson.core"     % "jackson-core",
   "com.fasterxml.jackson.core"     % "jackson-annotations",


### PR DESCRIPTION
Inspired by #763, #764 and #765