### PR TITLE
Removed the Lightbend CLA from the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,6 @@
 # Pull Request Checklist
 
 * [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
-* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
 * [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
 * [ ] Have you added copyright headers to new files?
 * [ ] Have you updated the documentation?


### PR DESCRIPTION
This removes the Lightbend CLA from the checklist, to avoid confusion.