### PR TITLE
update scala version settings

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11
-      scala: 2.12.16, 2.13.8, 3.2.0
+      scala: 2.12.x, 2.13.x, 3.x
       cmd: scripts/test-code.sh
 
   finish:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,5 @@
 object Dependencies {
-  // Sync with GA (.github/workflows/build-test.yml)
-  val Scala212 = "2.12.16" // sync! see comment above
-  val Scala213 = "2.13.8"  // sync! see comment above
-  val Scala3   = "3.2.0"   // sync! see comment above
+  val Scala212 = "2.12.16"
+  val Scala213 = "2.13.8"
+  val Scala3   = "3.2.0"
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes


## Purpose

use `semantic version selector` for scala version settings in github actions.


## Background Context


## References

https://github.com/sbt/sbt/releases/tag/v1.7.0


> ++ command updates
> Prior to sbt 1.7 ++ <sv> <command1> filtered subprojects using crossScalaVersions having the same ABI suffix as <sv>. This behavior was generally not well understood, and also created incorrect result for Scala 3.x since ++ 3.0.1 test could downgrade subproject that may require 3.1 or above.
> 
> sbt 1.7.0 fixes this by requiring ++ <sv> <command1> so <sv> part can be given as a [semantic version selector](https://github.com/npm/node-semver) expression, such as 3.1.x or 2.13.x. Note that the expression may match at most one Scala version to switch into. In sbt 1.7.0, a concrete version such as ++ 3.0.1 equires exact version to be present in crossScalaVersion.
