### PR TITLE
Remove .jvmopts not needed anymore

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,2 +1,0 @@
--Xss2M
--XX:ReservedCodeCacheSize=192m


### PR DESCRIPTION
Pretty sure it was added for Travis in ba865772d1616d774042620ce0d68802312dada7, but now we use GitHub actions