### PR TITLE
remove deprecated JsBoolean methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,16 @@ def playJsonMimaSettings = Seq(
     case _ => throw new Error("Unable to determine previous version")
   }),
   mimaBinaryIssueFilters ++= Seq(
+    // remove deprecated methods
+    // https://github.com/playframework/play-json/pull/861
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.JsBoolean.productArity"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.JsBoolean.productElement"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.JsBoolean.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.JsBoolean.copy$default$1"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.JsFalse.copy$default$1"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.JsFalse.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.JsTrue.copy$default$1"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.json.JsTrue.copy"),
     // MergedOWrites is private
     ProblemFilters.exclude[Problem]("play.api.libs.json.OWrites#MergedOWrites*"),
     // [error]  * in current version, classes mixing play.api.libs.json.DefaultWrites need be recompiled to wire to the new static mixin forwarder method all super calls to method enumNameWrites()play.api.libs.json.Writes

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
@@ -45,17 +45,6 @@ case object JsNull extends JsValue {
 sealed abstract class JsBoolean(val value: Boolean) extends JsValue with Product with Serializable {
   def canEqual(that: Any): Boolean = that.isInstanceOf[JsBoolean]
 
-  @deprecated("No longer a case class", "2.6.0")
-  val productArity = 1
-
-  @deprecated("No longer a case class", "2.6.0")
-  def productElement(n: Int): Any =
-    if (n == 0) value else throw new IndexOutOfBoundsException(s"Index out of range: $n")
-
-  @deprecated("No longer a case class", "2.6.0")
-  def copy(value: Boolean = this.value): JsBoolean =
-    if (value) JsTrue else JsFalse
-
   override def equals(that: Any): Boolean =
     canEqual(that) && (this.value == that.asInstanceOf[JsBoolean].value)
 


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

- Fixes https://github.com/playframework/play-json/issues/859

## Purpose

remove deprecated JsBoolean methods

## Background Context

maybe `val productArity = 1` cause `IndexOutOfBoundsException` on Scala 3.

## References
