### PR TITLE
Add Json.newBuilder utility

### DIFF
--- a/docs/manual/working/scalaGuide/main/json/ScalaJson.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJson.md
@@ -73,6 +73,10 @@ Represents a path into a `JsValue` structure, analogous to XPath for XML. This i
 
 @[convert-from-factory](code/ScalaJsonSpec.scala)
 
+You also can use `Json.newBuilder` to create `JsObject`:
+
+@[object-builder](code/ScalaJsonSpec.scala)
+
 ### Using Writes converters
 
 Scala to `JsValue` conversion is performed by the utility method `Json.toJson[T](T)(implicit writes: Writes[T])`. This functionality depends on a converter of type [`Writes[T]`](api/scala/play/api/libs/json/Writes.html) which can convert a `T` to a `JsValue`.

--- a/docs/manual/working/scalaGuide/main/json/code-2/Scala2JsonAutomatedSpec.scala
+++ b/docs/manual/working/scalaGuide/main/json/code-2/Scala2JsonAutomatedSpec.scala
@@ -4,7 +4,6 @@
 
 package scalaguide.json
 
-import play.api.libs.json.Json
 import org.specs2.mutable.Specification
 
 //#valueClass

--- a/play-json/shared/src/main/scala-2.13+/play/api/libs/json/JsObjectBuilder.scala
+++ b/play-json/shared/src/main/scala-2.13+/play/api/libs/json/JsObjectBuilder.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import scala.collection.mutable.{ Builder => MBuilder }
+
+private[json] final class JsObjectBuilder extends MBuilder[(String, Json.JsValueWrapper), JsObject] {
+
+  private val fs = Map.newBuilder[String, JsValue]
+
+  def addOne(elem: (String, Json.JsValueWrapper)): this.type = {
+    val (name, wrapped) = elem
+
+    fs += (name -> Json.unwrap(wrapped))
+
+    this
+  }
+
+  override def addAll(xs: IterableOnce[(String, Json.JsValueWrapper)]): this.type = {
+    xs.iterator.foreach(addOne)
+
+    this
+  }
+
+  override def knownSize: Int = fs.knownSize
+
+  override def sizeHint(size: Int): Unit = {
+    fs.sizeHint(size)
+  }
+
+  def clear(): Unit = {
+    fs.clear()
+  }
+
+  def result(): JsObject = JsObject(fs.result())
+}

--- a/play-json/shared/src/main/scala-2.13-/play/api/libs/json/JsObjectBuilder.scala
+++ b/play-json/shared/src/main/scala-2.13-/play/api/libs/json/JsObjectBuilder.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import scala.collection.mutable.{ Builder => MBuilder }
+
+private[json] final class JsObjectBuilder extends MBuilder[(String, Json.JsValueWrapper), JsObject] {
+
+  private val fs = Map.newBuilder[String, JsValue]
+
+  def +=(elem: (String, Json.JsValueWrapper)): this.type = {
+    val (name, wrapped) = elem
+
+    fs += (name -> Json.unwrap(wrapped))
+
+    this
+  }
+
+  override def ++=(xs: TraversableOnce[(String, Json.JsValueWrapper)]): this.type = {
+    xs.foreach(`+=`)
+
+    this
+  }
+
+  def knownSize: Int = fs.result().size
+
+  def clear(): Unit = {
+    fs.clear()
+  }
+
+  def result(): JsObject = JsObject(fs.result())
+}

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonSharedSpec.scala
@@ -135,6 +135,22 @@ class JsonSharedSpec extends AnyWordSpec with Matchers with org.scalatestplus.sc
       "js.toJsObject(peach)(writes)".mustNot(typeCheck)
     }
 
+    "create object using builder" in {
+      val builder = Json.newBuilder
+
+      builder += ("name" -> "John Doe")
+      builder += ("age"  -> 25)
+
+      val result: JsObject = builder.result()
+
+      result.mustEqual(
+        Json.obj(
+          "name" -> "John Doe",
+          "age"  -> 25
+        )
+      )
+    }
+
     "convert to a byte array containing the UTF-8 representation" in json { js =>
       val json = js.parse("""
                             |{


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

Add an utility function `Json.newBuilder` (similar to `Map.newBuilder`):

```scala
import play.api.libs.json.{ Json, JsObject }

// Create a new builder
val builder: JsObjectBuilder = JsObject.newBuilder

// Add key-value pairs to the builder
builder += ("name" -> "John Doe")
builder += ("age" -> 25)

// Clear the builder
builder.clear()

// Add more key-value pairs
builder += ("email" -> "john.doe@example.com")
builder += ("address" -> "123 Street")

// Build the final JsObject
val result: JsObject = builder.result()

// Print the resulting JsObject
println(result)
```

Will print:

```json
{"email":"john.doe@example.com","address":"123 Street"}
```