### PR TITLE
Improve performance of json lookups in case of errors

### DIFF
--- a/benchmarks/src/main/scala/play/api/libs/json/JsLookupBench.scala
+++ b/benchmarks/src/main/scala/play/api/libs/json/JsLookupBench.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+  jvmArgsAppend =
+    Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:-BackgroundCompilation", "-XX:-TieredCompilation"),
+  value = 1
+)
+class JsLookupBench {
+  @Param(Array("1", "20", "100"))
+  var size: Int                  = _
+  private var jsObject: JsObject = _
+
+  @Setup def setup(): Unit = {
+    jsObject = JsObject(0.until(size).map(i => i.toString -> JsString(s"This is my content for index $i")))
+  }
+
+  @Benchmark
+  def goodLookup: Option[String] = (jsObject \ (size - 1).toString).asOpt[String]
+
+  @Benchmark
+  def badLookup: Option[String] = (jsObject \ (size + 1).toString).asOpt[String]
+}

--- a/benchmarks/src/main/scala/play/api/libs/json/JsObjectBench.scala
+++ b/benchmarks/src/main/scala/play/api/libs/json/JsObjectBench.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play.api.libs.json
 
 import org.openjdk.jmh.annotations._

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -104,7 +104,9 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
       obj.underlying
         .get(fieldName)
         .map(JsDefined.apply)
-        .getOrElse(JsUndefined(s"'$fieldName' is undefined on object: $obj"))
+        .getOrElse(
+          JsUndefined(s"'$fieldName' is undefined on object. Available keys are ${obj.keys.mkString("'", "', '", "'")}")
+        )
     case JsDefined(o) =>
       JsUndefined(s"$o is not an object")
     case undef => undef


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Purpose

Improve performance of json lookup `\` when encountering bad json.

## Background Context

When a bad json was encountered, the json object was copied in the error message. This message could often be discarded, when using `asOpt` for instance. 
The issue was especially present when parsing big json objects (> 10MB). As the program was busy serializing the json into a string.
Here we still give the user the available keys in the object to be helpful.


```
# BEFORE

[info] Benchmark                 (size)   Mode  Cnt      Score      Error   Units
[info] JsLookupBench.badLookup        1  thrpt   10    981.947 ±  443.761  ops/ms
[info] JsLookupBench.badLookup       20  thrpt   10    360.393 ±   39.503  ops/ms
[info] JsLookupBench.badLookup      100  thrpt   10     94.659 ±    9.231  ops/ms
[info] JsLookupBench.goodLookup       1  thrpt   10  32872.983 ± 2745.549  ops/ms
[info] JsLookupBench.goodLookup      20  thrpt   10  25447.611 ± 7564.005  ops/ms
[info] JsLookupBench.goodLookup     100  thrpt   10  30841.130 ±  984.572  ops/ms

# AFTER

[info] JsLookupBench.badLookup        1  thrpt   10   6949.590 ± 770.618  ops/ms
[info] JsLookupBench.badLookup       20  thrpt   10   1644.751 ±  12.360  ops/ms
[info] JsLookupBench.badLookup      100  thrpt   10    393.848 ±   5.391  ops/ms
[info] JsLookupBench.goodLookup       1  thrpt   10  35988.524 ± 645.783  ops/ms
[info] JsLookupBench.goodLookup      20  thrpt   10  33995.451 ± 504.901  ops/ms
[info] JsLookupBench.goodLookup     100  thrpt   10  31899.440 ± 477.421  ops/ms
```

## References

Are there any relevant issues / PRs / mailing lists discussions?
