### PR TITLE
Group Scala Steward patch updates into single PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,9 +1,10 @@
-pullRequests.frequency = "@weekly"
-
-updates.pin  = [
-]
+pullRequests.frequency = "@monthly"
 
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
+
+pullRequests.grouping = [
+  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] }
+]
 
 updates.ignore = [
   // these will get updated along with jackson-core, so no need to update them separately


### PR DESCRIPTION
Patch updates are likey to not break anything so we can just put them into one PR.