### PR TITLE
fix JsonMemoryFootprintSpec with JDK 21

### DIFF
--- a/play-json/jvm/src/test/scala-3/play/api/libs/json/JsonMemoryFootprintSpec.scala
+++ b/play-json/jvm/src/test/scala-3/play/api/libs/json/JsonMemoryFootprintSpec.scala
@@ -6,14 +6,28 @@ package play.api.libs.json
 
 import org.openjdk.jol.info.GraphLayout
 import org.scalatest.freespec.AnyFreeSpec
+import scala.util.Properties
 import scala.util.chaining._
 
 class JsonMemoryFootprintSpec extends AnyFreeSpec {
 
+  private def pendingIfJdk21() = {
+    if (Properties.isJavaAtLeast("21")) {
+      // https://github.com/playframework/play-json/pull/929
+      pending
+    }
+  }
+
   "Json.parse" - {
     "obj0" in assertSizes("""{}""", 16, 16)
-    "obj1" in assertSizes("""{"1":true}""", 152, 168)
-    "obj4" in assertSizes("""{"1":true,"2":true,"3":true,"4":true}""", 296, 312)
+    "obj1" in {
+      pendingIfJdk21()
+      assertSizes("""{"1":true}""", 152, 168)
+    }
+    "obj4" in {
+      pendingIfJdk21()
+      assertSizes("""{"1":true,"2":true,"3":true,"4":true}""", 296, 312)
+    }
 
     "arr0" in assertSizes("""[]""", 40, 40)
     "arr1" in assertSizes("""[true]""", 120, 120)
@@ -33,10 +47,19 @@ class JsonMemoryFootprintSpec extends AnyFreeSpec {
   "JsObject" - {
     def obj(json: String) = Json.parse(json).as[JsObject]
     "obj0 ++ obj0" in assertSize(obj("{}") ++ obj("{}"), 16)
-    "obj0 ++ obj1" in assertSize(obj("{}") ++ obj("""{"1":true}"""), 152)
-    "obj1 ++ obj0" in assertSize(obj("""{"1":true}""") ++ obj("""{}"""), 152)
+    "obj0 ++ obj1" in {
+      pendingIfJdk21()
+      assertSize(obj("{}") ++ obj("""{"1":true}"""), 152)
+    }
+    "obj1 ++ obj0" in {
+      pendingIfJdk21()
+      assertSize(obj("""{"1":true}""") ++ obj("""{}"""), 152)
+    }
 
-    "obj1.value" in assertSize(obj("""{"1":true}""").tap(_.value), 152)
+    "obj1.value" in {
+      pendingIfJdk21()
+      assertSize(obj("""{"1":true}""").tap(_.value), 152)
+    }
   }
 
   "malicious" - {
@@ -44,7 +67,10 @@ class JsonMemoryFootprintSpec extends AnyFreeSpec {
     def arr1KB(elem: String, targetSize: Int = 1000): String =
       Iterator.continually(elem).take(targetSize / (elem.length + 1)).mkString("[", ",", "]")
     "obj0" in assertSizes(arr1KB("{}"), 7432, 7432)
-    "obj1" in assertSizes(arr1KB("""{"a":6}"""), 29568, 31568)
+    "obj1" in {
+      pendingIfJdk21()
+      assertSizes(arr1KB("""{"a":6}"""), 29568, 31568)
+    }
     "nums" in assertSizes(arr1KB("6"), 42104, 42104)
     "arr0" in assertSizes(arr1KB("[]"), 15424, 15424)
     "arr1" in assertSizes(arr1KB("[6]"), 51080, 51080)


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes


## Purpose

pending some test if JDK 21 because fail.

## Background Context


https://github.com/openjdk/jdk/commit/17ce0976e442d5fabb14daed40fa9a768989f02e#diff-cdf6d0587f1021c14e1af0d9cab581de2809cd1dbcf8bd87f5a5a304dc087263R333

add `int putMode` since JDK 21.

inspect `java.util.LinkedHashMap` by jol

### JDK 17 

```
java.util.LinkedHashMap object internals:
 OFFSET  SIZE       TYPE DESCRIPTION                    VALUE
      0     4            (object header)                01 00 00 00 (00000001 00000000 00000000 00000000) (1)
      4     4            (object header)                00 00 00 00 (00000000 00000000 00000000 00000000) (0)
      8     4            (object header)                d8 65 11 00 (11011000 01100101 00010001 00000000) (1140184)
     12     4        Set AbstractMap.keySet             (access denied)
     16     4 Collection AbstractMap.values             (access denied)
     20     4        int HashMap.size                   (access denied)
     24     4        int HashMap.modCount               (access denied)
     28     4        int HashMap.threshold              (access denied)
     32     4      float HashMap.loadFactor             (access denied)
     36     4     Node[] HashMap.table                  (access denied)
     40     4        Set HashMap.entrySet               (access denied)
     44     1    boolean LinkedHashMap.accessOrder      (access denied)
     45     3            (alignment/padding gap)        N/A
     48     4      Entry LinkedHashMap.head             (access denied)
     52     4      Entry LinkedHashMap.tail             (access denied)
Instance size: 56 bytes
Space losses: 3 bytes internal + 0 bytes external = 3 bytes total
```

### JDK 21

```
java.util.LinkedHashMap object internals:
 OFFSET  SIZE       TYPE DESCRIPTION                    VALUE
      0     4            (object header)                01 00 00 00 (00000001 00000000 00000000 00000000) (1)
      4     4            (object header)                00 00 00 00 (00000000 00000000 00000000 00000000) (0)
      8     4            (object header)                b8 d7 0f 00 (10111000 11010111 00001111 00000000) (1038264)
     12     4        Set AbstractMap.keySet             (access denied)
     16     4 Collection AbstractMap.values             (access denied)
     20     4        int HashMap.size                   (access denied)
     24     4        int HashMap.modCount               (access denied)
     28     4        int HashMap.threshold              (access denied)
     32     4      float HashMap.loadFactor             (access denied)
     36     4     Node[] HashMap.table                  (access denied)
     40     4        Set HashMap.entrySet               (access denied)
     44     4        int LinkedHashMap.putMode          (access denied)
     48     1    boolean LinkedHashMap.accessOrder      (access denied)
     49     3            (alignment/padding gap)        N/A
     52     4      Entry LinkedHashMap.head             (access denied)
     56     4      Entry LinkedHashMap.tail             (access denied)
     60     4            (loss due to the next object alignment)
Instance size: 64 bytes
Space losses: 3 bytes internal + 4 bytes external = 7 bytes total
```

## References
