### PR TITLE
make ImmutableLinkedHashMap serializable

### DIFF
--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsObjectSerializationSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsObjectSerializationSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import org.specs2.mutable._
+import play.api.libs.json.Json._
+
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream }
+
+class JsObjectSerializationSpec extends Specification {
+  "JsObject" should {
+    "serialize/deserialize correctly" in {
+      val originalObj = Json.obj(
+        "field1" -> 123,
+        "field2" -> "abc",
+        "field3" -> JsNull,
+        "obj"    -> Json.obj("field1" -> 234),
+        "arr" -> JsArray(
+          Seq(
+            JsString("abc"),
+            JsNumber(123),
+            JsBoolean(true),
+            JsNull,
+            Json.obj("field1" -> 345)
+          )
+        )
+      )
+
+      val bos = new ByteArrayOutputStream()
+      val out = new ObjectOutputStream(bos)
+      out.writeObject(originalObj)
+
+      val bis = new ByteArrayInputStream(bos.toByteArray)
+      val in  = new ObjectInputStream(bis)
+      in.readObject().asInstanceOf[JsObject].must(beEqualTo(originalObj))
+    }
+  }
+}

--- a/play-json/shared/src/main/scala-2.13+/play/api/libs/json/ImmutableLinkedHashMap.scala
+++ b/play-json/shared/src/main/scala-2.13+/play/api/libs/json/ImmutableLinkedHashMap.scala
@@ -13,7 +13,10 @@ import scala.collection.mutable
 /**
  * Wraps a Java LinkedHashMap as a Scala immutable.Map.
  */
-private[json] class ImmutableLinkedHashMap[A, +B](underlying: JLinkedHashMap[A, B]) extends AbstractMap[A, B] {
+@SerialVersionUID(-2338626292552177485L)
+private[json] class ImmutableLinkedHashMap[A, +B](underlying: JLinkedHashMap[A, B])
+    extends AbstractMap[A, B]
+    with Serializable {
 
   override def get(key: A): Option[B] = Option(underlying.get(key))
 

--- a/play-json/shared/src/main/scala-2.13-/play/api/libs/json/ImmutableLinkedHashMap.scala
+++ b/play-json/shared/src/main/scala-2.13-/play/api/libs/json/ImmutableLinkedHashMap.scala
@@ -17,10 +17,11 @@ import scala.collection.mutable.ArrayBuffer
 /**
  * Wraps a Java LinkedHashMap as a Scala immutable.Map.
  */
+@SerialVersionUID(-2338626292552177485L)
 private[json] class ImmutableLinkedHashMap[A, +B](underlying: JLinkedHashMap[A, B])
     extends AbstractMap[A, B]
     with Map[A, B]
-    with MapLike[A, B, ImmutableLinkedHashMap[A, B]] {
+    with MapLike[A, B, ImmutableLinkedHashMap[A, B]] with Serializable {
 
   override def get(key: A): Option[B] = Option(underlying.get(key))
 

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsValue.scala
@@ -33,6 +33,7 @@ object JsValue {
  * Represents a Json null value.
  */
 case object JsNull extends JsValue {
+  @transient
   implicit val reads: Reads[JsNull.type] = Reads[JsNull.type] {
     case JsNull => JsSuccess(JsNull)
     case _      => JsError("error.expected.null")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #944 

## Purpose

In order to be able to serialize objects that contain JsObject as a member need to have internal underlying ImmutableLinkedHashMap implement serializable interface