### PR TITLE
[2.10.x] Revert "play-docs-sbt-plugin 3.0.1 (was 2.9.1) (#980)"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("org.playframework" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "3.0.1"))
+addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.9.1"))
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 


### PR DESCRIPTION
This reverts commit 93f48a28be109551c086b316a2d7919af580904e.

Because in the 2.10 branch we still are on Play 2.9.x and the com.typesafe groupId.