### PR TITLE
Fix #974 – Scala 3 macro cannot find Writes for Seq[Map[String, T]]

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
@@ -366,7 +366,7 @@ trait DefaultWrites extends LowPriorityWrites with EnumerationWrites {
    * Serializer for Map[String,V] types.
    */
   @deprecated("Use `genericMapWrites`", "2.8.0")
-  implicit def mapWrites[V: Writes]: OWrites[MapWrites.Map[String, V]] = MapWrites.mapWrites
+  def mapWrites[V: Writes]: OWrites[MapWrites.Map[String, V]] = MapWrites.mapWrites
 
   implicit def keyMapWrites[K: KeyWrites, V: Writes, M[K, V] <: MapWrites.Map[K, V]]: OWrites[M[K, V]] = {
     val kw = implicitly[KeyWrites[K]]

--- a/play-json/shared/src/test/scala/play/api/libs/json/WritesSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/WritesSharedSpec.scala
@@ -84,6 +84,10 @@ final class WritesSharedSpec extends AnyWordSpec with Matchers {
     "write lazy maps" in {
       Json.toJson(Map("a" -> 1).map(kv => kv._1 -> (kv._2 + 1))).mustEqual(Json.obj("a" -> 2))
     }
+
+    "write a map nested in a seq" in {
+      Json.toJson(Seq(Map("a" -> 1))).mustEqual(Json.arr(Json.obj("a" -> 1)))
+    }
   }
 
   "Iterable writes" should {


### PR DESCRIPTION
Moved the deprecated method `DefaultWrites.mapWrites` into `LowPriorityWrites` to get rid of the ambiguity.

# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #974 – Scala 3 macro cannot find Writes for Seq[Map[String, T]]

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
