### PR TITLE
refactor Jackson code to hardcode buffer-recycler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,12 +21,12 @@ def specs2(scalaVersion: String) =
     ("org.specs2" %% s"specs2-$n" % "4.20.5") % Test
   }
 
-val jacksonDatabindVersion = "2.14.3"
+val jacksonDatabindVersion = "2.16.2"
 val jacksonDatabind = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 )
 
-val jacksonVersion = "2.14.3"
+val jacksonVersion = "2.16.2"
 val jacksons = Seq(
   "com.fasterxml.jackson.core"     % "jackson-core",
   "com.fasterxml.jackson.core"     % "jackson-annotations",


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

partial fix for #998 

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

JsonFactory should be used to create ObjectMappers - not the other way around.

ThreadLocal buffer-recycler is the default up to and including Jackson 2.16. Default was changed in Jackson 2.17 but the way play-json uses Jackson is likely to suffer performance wise with the new default.

You might want to make the buffer-recycler configurable like in https://github.com/apache/incubator-pekko-http/pull/519

Upgrading to Jackson 2.15 and above also brings in Jackson's [StreamReadConstraints](https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.17.0/com/fasterxml/jackson/core/StreamReadConstraints.html) and [StreamWriteConstraints](https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.17.0/com/fasterxml/jackson/core/StreamWriteConstraints.html). 

play-json has its own number parsing checks so I disabled the Jackson check. There are other checks in StreamReadConstraints and StreamWriteConstraints and play-json needs to decide if you want to make them configurable or if you want to disable the Jackson checks.


## References

Are there any relevant issues / PRs / mailing lists discussions?
