### PR TITLE
Revert "sbt-scalajs, scalajs-compiler, ... 1.16.0 (was 1.15.0)"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ lazy val `play-json` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       libraryDependencies ++= Seq(
         "org.scalatest"     %%% "scalatest"       % "3.2.18"   % Test,
         "org.scalatestplus" %%% "scalacheck-1-16" % "3.2.14.0" % Test,
-        "org.scalacheck"    %%% "scalacheck"      % "1.17.1"   % Test,
+        "org.scalacheck"    %%% "scalacheck"      % "1.17.0"   % Test,
       ),
       libraryDependencies += {
         if (isScala3.value) {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.15.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 


### PR DESCRIPTION
Reverts playframework/play-json#1006

We did not merge this in twirl, so let's do the same for play-json, see comments starting here: https://github.com/playframework/twirl/pull/750#issuecomment-2076890907