### PR TITLE
Run tests with Java 21 also

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,7 +40,7 @@ jobs:
       - "check-docs"
     uses: playframework/.github/.github/workflows/cmd.yml@v4
     with:
-      java: 17, 11
+      java: 21, 17, 11
       scala: 2.12.x, 2.13.x, 3.x
       cmd: scripts/test-code.sh
 


### PR DESCRIPTION
I think back then it was not available in the coursier index.