### PR TITLE
Add test for constructing Writes with case class

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,19 +246,28 @@ import play.api.libs.functional.syntax._
 implicit val locationWrites: Writes[Location] = (
   (JsPath \ "lat").write[Double] and
   (JsPath \ "long").write[Double]
-)(unlift(Location.unapply))
+)(location => {
+  val Location(lat, long) = location
+  (lat, long)
+})
 
 implicit val residentWrites: Writes[Resident] = (
   (JsPath \ "name").write[String] and
   (JsPath \ "age").write[Int] and
   (JsPath \ "role").writeNullable[String]
-)(unlift(Resident.unapply))
+)(resident => {
+  val Resident(name, age, role) = resident
+  (name, age, role)
+})
 
 implicit val placeWrites: Writes[Place] = (
   (JsPath \ "name").write[String] and
   (JsPath \ "location").write[Location] and
   (JsPath \ "residents").write[Seq[Resident]]
-)(unlift(Place.unapply))
+)(place => {
+  val Place(name, location, residents) = place
+  (name, location, residents)
+})
 
 
 val place = Place(

--- a/play-json/shared/src/test/scala/play/api/libs/json/WritesSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/WritesSharedSpec.scala
@@ -174,6 +174,31 @@ final class WritesSharedSpec extends AnyWordSpec with Matchers {
     success[JsValue, Writes](JsString("foo"))
   }
 
+  "Constructing Writes" should {
+    "support case class" in {
+      import play.api.libs.functional.syntax._
+
+      implicit val locationReads: Reads[Location] = (
+        (JsPath \ "lat").read[Double] and
+          (JsPath \ "long").read[Double]
+      )(Location.apply _)
+
+      implicit val locationWrites: Writes[Location] = (
+        (JsPath \ "lat").write[Double] and
+          (JsPath \ "long").write[Double]
+      )(location => {
+        val Location(lat, long) = location
+        (lat, long)
+      })
+
+      val location = Location(1.1, 2.2)
+
+      val serialized = Json.stringify(Json.toJson(location))
+      serialized.mustEqual("""{"lat":1.1,"long":2.2}""")
+      Json.fromJson[Location](Json.parse(serialized)).mustEqual(JsSuccess(location))
+    }
+  }
+
   // ---
 
   case class Location(lat: Double, long: Double)


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [X] Have you added copyright headers to new files? N/A
* [X] Have you updated the documentation? N/A
* [X] Have you added tests for any changed functionality? N/A

## Background

The syntax in the README for constructing Writes fails to compile in Scala 3:
```
[error] -- [E007] Type Mismatch Error:
[error] 189 |        ) (unlift(Location.unapply))
[error]     |                  ^^^^^^^^^^^^^^^^
[error]     |                  Found:    Location
[error]     |                  Required: Option[Any]
```

This is due to the following change to case class unapply: https://docs.scala-lang.org/scala3/guides/migration/incompat-other-changes.html#explicit-call-to-unapply

Following the guidance from the migration guide pattern binding is used instead of call to unapply.

This PR fixes #1039 by updating the syntax in README to support Scala 3 and add new unit test.