### PR TITLE
Added tests to format value classes

### DIFF
--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -115,6 +115,8 @@ object CustomApply {
 
 case class Optional(props: Option[String])
 
+case class UserId(id: Long) extends AnyVal
+
 class JsonExtensionSpec extends AnyWordSpec with Matchers {
   "JsonExtension" should {
     "create a reads[User]" in {
@@ -748,6 +750,20 @@ class JsonExtensionSpec extends AnyWordSpec with Matchers {
       formatter.reads(Json.obj()).mustEqual(JsSuccess(Optional(None)))
       formatter.reads(Json.obj("props" -> JsNull)).mustEqual(JsSuccess(Optional(None)))
       formatter.reads(Json.obj("props" -> Some("foo"))).mustEqual(JsSuccess(Optional(Some("foo"))))
+    }
+    "format value classes" in {
+      implicit val userIdFmt: Format[UserId] = Json.format[UserId]
+      val userId                             = UserId(12345)
+      val serialized                         = Json.stringify(Json.toJson(userId))
+      serialized.mustEqual("""{"id":12345}""")
+      Json.fromJson[UserId](Json.parse(serialized)).mustEqual(JsSuccess(userId))
+    }
+    "format value classes with value format" in {
+      implicit val userIdFmt: Format[UserId] = Json.valueFormat[UserId]
+      val userId                             = UserId(12345)
+      val serialized                         = Json.stringify(Json.toJson(userId))
+      serialized.mustEqual("""12345""")
+      Json.fromJson[UserId](Json.parse(serialized)).mustEqual(JsSuccess(userId))
     }
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [X] Have you added copyright headers to new files? N/A
* [X] Have you updated the documentation? N/A
* [X] Have you added tests for any changed functionality? N/A

## Purpose

This PR demonstrates #1011. The Json.format[UserId] fails to compile with Scala 3:
```
[error] -- Error: JsonExtensionSpec.scala:755:58
[error] 755 |      implicit val userIdFmt: Format[UserId] = Json.format[UserId]
[error]     |                                               ^^^^^^^^^^^^^^^^^^^
[error]     |            Instance not found: 'ProductOf[play.api.libs.json.UserId]'
```

