### PR TITLE
reduce `JsSuccess` and `JsError` instance size

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsResult.scala
@@ -12,8 +12,8 @@ import scala.collection.Seq
 case class JsSuccess[T](value: T, path: JsPath = JsPath()) extends JsResult[T] {
   def get: T = value
 
-  val isSuccess = true
-  val isError   = false
+  def isSuccess = true
+  def isError   = false
 
   def fold[U](invalid: Seq[(JsPath, Seq[JsonValidationError])] => U, valid: T => U): U = valid(value)
 
@@ -60,8 +60,8 @@ case class JsError(errors: Seq[(JsPath, Seq[JsonValidationError])]) extends JsRe
   def +:(error: (JsPath, JsonValidationError)): JsError      = JsError.merge(JsError(error), this)
   def prepend(error: (JsPath, JsonValidationError)): JsError = this.+:(error)
 
-  val isSuccess = false
-  val isError   = true
+  def isSuccess = false
+  def isError   = true
 
   def fold[U](invalid: Seq[(JsPath, Seq[JsonValidationError])] => U, valid: Nothing => U): U = invalid(errors)
 
@@ -84,7 +84,7 @@ case class JsError(errors: Seq[(JsPath, Seq[JsonValidationError])]) extends JsRe
 
   def orElse[U >: Nothing](t: => JsResult[U]): JsResult[U] = t
 
-  val asOpt = None
+  def asOpt = None
 
   def asEither: Either[Seq[(JsPath, Seq[JsonValidationError])], Nothing] = Left(errors)
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes


## Purpose

reduce instance size

https://github.com/openjdk/jol

#### before

```
play.api.libs.json.JsError object internals:
OFF  SZ                   TYPE DESCRIPTION               VALUE
  0   8                        (object header: mark)     N/A
  8   4                        (object header: class)    N/A
 12   1                boolean JsError.isSuccess         N/A
 13   1                boolean JsError.isError           N/A
 14   2                        (alignment/padding gap)
 16   4   scala.collection.Seq JsError.errors            N/A
 20   4            scala.None$ JsError.asOpt             N/A
Instance size: 24 bytes
Space losses: 2 bytes internal + 0 bytes external = 2 bytes total
```

#### after

```
play.api.libs.json.JsError object internals:
OFF  SZ                   TYPE DESCRIPTION               VALUE
  0   8                        (object header: mark)     N/A
  8   4                        (object header: class)    N/A
 12   4   scala.collection.Seq JsError.errors            N/A
Instance size: 16 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

## Background Context

I think more efficient and simple use `def` instead `val` if return constant value. because `val` generate internal private non-static field.

```scala
class A { val x = true ; def y = true }
```

javap result

```
  public boolean x();
    descriptor: ()Z
    flags: ACC_PUBLIC
    Code:
      stack=1, locals=1, args_size=1
         0: aload_0
         1: getfield      #18                 // Field x:Z
         4: ireturn

  public boolean y();
    descriptor: ()Z
    flags: ACC_PUBLIC
    Code:
      stack=1, locals=1, args_size=1
         0: iconst_1
         1: ireturn
```


## References

