### PR TITLE
try to avoid reparsing numbers as BigDecimal when serializing

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -98,8 +98,10 @@ private[jackson] class JsValueSerializer(jsonConfig: JsonConfig) extends JsonSer
 
         if (raw.indexOf('E') < 0 && raw.indexOf('.') < 0)
           json.writeTree(new BigIntegerNode(new BigInteger(raw)))
-        else
+        else if (shouldWritePlain)
           json.writeTree(new DecimalNode(new JBigDec(raw)))
+        else
+          json.writeTree(new DecimalNode(stripped))
       }
 
       case JsString(v)  => json.writeString(v)


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

Parsing numbers from strings is expensive. This PR covers one case where a BigDecimal is converted to a String (expensive too) and then parsed again as a BigDecimal. This PR skips the final parse and just uses the BigDecimal instance that we already have. 

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
