### PR TITLE
avoid reparsing numbers when serializing

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -100,8 +100,8 @@ private[jackson] class JsValueSerializer(jsonConfig: JsonConfig) extends JsonSer
           json.writeNumber(raw)
         else
           json match {
-            case _: TokenBuffer =>
-              json.writeTree(new BigIntegerNode(new BigInteger(raw)))
+            case tb: TokenBuffer =>
+              tb.writeNumber(raw, true)
             case _ =>
               json.writeNumber(raw)
           }

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -6,7 +6,6 @@ package play.api.libs.json.jackson
 
 import java.io.InputStream
 import java.io.StringWriter
-import java.math.BigInteger
 
 import scala.annotation.switch
 import scala.annotation.tailrec
@@ -28,7 +27,6 @@ import com.fasterxml.jackson.databind.`type`.TypeFactory
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.node.BigIntegerNode
 import com.fasterxml.jackson.databind.ser.Serializers
 import com.fasterxml.jackson.databind.util.TokenBuffer
 

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -6,6 +6,7 @@ package play.api.libs.json.jackson
 
 import java.io.InputStream
 import java.io.StringWriter
+import java.math.BigInteger
 
 import scala.annotation.switch
 import scala.annotation.tailrec
@@ -27,7 +28,9 @@ import com.fasterxml.jackson.databind.`type`.TypeFactory
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.node.BigIntegerNode
 import com.fasterxml.jackson.databind.ser.Serializers
+import com.fasterxml.jackson.databind.util.TokenBuffer
 
 import play.api.libs.json._
 
@@ -68,11 +71,7 @@ sealed class PlayJsonMapperModule(jsonConfig: JsonConfig) extends SimpleModule("
 // -- Serializers.
 
 private[jackson] class JsValueSerializer(jsonConfig: JsonConfig) extends JsonSerializer[JsValue] {
-  import java.math.BigInteger
   import java.math.{ BigDecimal => JBigDec }
-
-  import com.fasterxml.jackson.databind.node.BigIntegerNode
-  import com.fasterxml.jackson.databind.node.DecimalNode
 
   private def stripTrailingZeros(bigDec: JBigDec): JBigDec = {
     val stripped = bigDec.stripTrailingZeros
@@ -97,10 +96,15 @@ private[jackson] class JsValueSerializer(jsonConfig: JsonConfig) extends JsonSer
         val stripped = stripTrailingZeros(v.bigDecimal)
         val raw      = if (shouldWritePlain) stripped.toPlainString else stripped.toString
 
-        if (raw.indexOf('E') < 0 && raw.indexOf('.') < 0)
-          json.writeTree(new BigIntegerNode(new BigInteger(raw)))
+        if (raw.exists(c => c == 'E' || c == '.'))
+          json.writeNumber(raw)
         else
-          json.writeTree(new DecimalNode(new JBigDec(raw)))
+          json match {
+            case _: TokenBuffer =>
+              json.writeTree(new BigIntegerNode(new BigInteger(raw)))
+            case _ =>
+              json.writeNumber(raw)
+          }
       }
 
       case JsString(v)  => json.writeString(v)


### PR DESCRIPTION
Alternative to #1073 

This change avoids creating NumericNodes and parsing strings to numbers which ultimately have to be turned back to strings to write them.

I've had to leave the BigIntegerNode usage in there. Removing it breaks some tests. I've debugged and it is down to how writeNumber(String) is implemented in jackson-databind TokenBuffer. We would need to change this class in jackson-databind to fix this (and that is not likely to happen as it will probably cause other issues). Basically, writeNumber(String) is assumed to be a non-integer in TokenBuffer.