### PR TITLE
Remove unnecessary error generation when JsValue.asOpt is used on a missing key

### DIFF
--- a/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -195,9 +195,10 @@ case class JsDefined(value: JsValue) extends AnyVal with JsLookupResult
  * Represent a missing Json value.
  */
 final class JsUndefined(err: => String) extends JsLookupResult {
-  def error             = err
-  def validationError   = JsonValidationError(error)
-  override def toString = s"JsUndefined($err)"
+  def error                                                = err
+  def validationError                                      = JsonValidationError(error)
+  override def toString                                    = s"JsUndefined($err)"
+  override def asOpt[T](implicit fjs: Reads[T]): Option[T] = None
 }
 
 object JsUndefined {


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Purpose

We discovered that in many cases, when JSON is parsed, `asOpt` is used to read an optional key. This results in a performance penalty because an error is generated each time, but it is not used in any way, as described in the documentation for `asOpt`.

When `asOpt` is used on a missing key, it is called on the `JsUndefined` object. This triggers the execution of the `asOpt` function in `JsReadable`, which performs unnecessary validation and ultimately returns `None` after constructing a large number of unnecessary strings.

An example of this issue can be seen in the following flame graph:
![image](https://github.com/user-attachments/assets/d36ae471-2e31-4132-a34b-701fa37ce460)

A simple fix would be to always return `None` when `asOpt` is called on the `JsUndefined` object.

We tested the performance of the function on version `3.0.4` witch `Scala 2.13.14` and `Java 21` with and without the fix, and the results are as follows:

Original version
```
[info] # Warmup Iteration   1: 16656.253 ops/ms
[info] # Warmup Iteration   2: 16971.747 ops/ms
[info] # Warmup Iteration   3: 17315.722 ops/ms
[info] # Warmup Iteration   4: 17300.985 ops/ms
[info] # Warmup Iteration   5: 17355.655 ops/ms
[info] Iteration   1: 17318.713 ops/ms
[info] Iteration   2: 17324.471 ops/ms
[info] Iteration   3: 17366.688 ops/ms
[info] Iteration   4: 17339.576 ops/ms
[info] Iteration   5: 17317.734 ops/ms
[info] Result "play.api.libs.json.AsOptJsonBenchmark.readNonExistentField":
[info]   17333.436 ±(99.9%) 79.080 ops/ms [Average]
[info]   (min, avg, max) = (17317.734, 17333.436, 17366.688), stdev = 20.537
[info]   CI (99.9%): [17254.356, 17412.517] (assumes normal distribution)
[info] # Run complete. Total time: 00:01:40
[info] Benchmark                                 Mode  Cnt      Score    Error   Units
[info] AsOptJsonBenchmark.readNonExistentField  thrpt    5  17333.436 ± 79.080  ops/ms
```
Fixed version
```
[info] # Warmup Iteration   1: 387805.387 ops/ms
[info] # Warmup Iteration   2: 395776.593 ops/ms
[info] # Warmup Iteration   3: 396521.421 ops/ms
[info] # Warmup Iteration   4: 396692.480 ops/ms
[info] # Warmup Iteration   5: 396071.469 ops/ms
[info] Iteration   1: 395516.846 ops/ms
[info] Iteration   2: 396267.266 ops/ms
[info] Iteration   3: 396287.878 ops/ms
[info] Iteration   4: 396425.990 ops/ms
[info] Iteration   5: 396137.772 ops/ms
[info] Result "play.api.libs.json.AsOptJsonBenchmark.readNonExistentField":
[info]   396127.150 ±(99.9%) 1371.385 ops/ms [Average]
[info]   (min, avg, max) = (395516.846, 396127.150, 396425.990), stdev = 356.144
[info]   CI (99.9%): [394755.766, 397498.535] (assumes normal distribution)
[info] # Run complete. Total time: 00:01:40
[info] Benchmark                                 Mode  Cnt       Score      Error   Units
[info] AsOptJsonBenchmark.readNonExistentField  thrpt    5  396127.150 ± 1371.385  ops/ms
```

As can easily be seen, the throughput increase is significant, and in our experience, in real-world applications, usually 70% of the time spent in asOpt will be saved in applications that frequently try to access missing keys.

The following code was used to test the throughput:
```
package play.api.libs.json

import org.openjdk.jmh.annotations._
import org.openjdk.jmh.infra.Blackhole
import java.util.concurrent.TimeUnit

@BenchmarkMode(Array(Mode.Throughput))
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Thread)
@Fork(value = 1)
class AsOptJsonBenchmark {
  var json: JsObject = _

  @Setup(Level.Trial)
  def prepare(): Unit = {
    json = Json.obj("existingField" -> "value")
  }

  @Benchmark
  def readNonExistentField(blackhole: Blackhole): Unit = {
    blackhole.consume((json \ "nonExistentField").asOpt[String])
  }
}

```

