### PR TITLE
update `.scalafmt.conf`. enforce new wildcard syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -52,3 +52,11 @@ fileOverride {
 project.excludePaths = [
   "glob:**/docs/**/code*/*.scala"
 ]
+
+rewrite.scala3.convertToNewSyntax = true
+runner.dialectOverride {
+  allowSignificantIndentation = false
+  allowAsForImportRename = false
+  allowStarWildcardImport = false
+  allowPostfixStarVarargSplices = false
+}

--- a/play-json/js/src/main/scala/StaticBinding.scala
+++ b/play-json/js/src/main/scala/StaticBinding.scala
@@ -40,7 +40,7 @@ object StaticBinding {
     case l: Long        => JsNumber(l)
     case true           => JsTrue
     case false          => JsFalse
-    case a: js.Array[_] => JsArray(a.map(anyToJsValue).toArray[JsValue])
+    case a: js.Array[?] => JsArray(a.map(anyToJsValue).toArray[JsValue])
 
     case o: js.Object => {
       JsObject((for {

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -150,7 +150,7 @@ private[jackson] case class ReadingMap(content: ListBuffer[(String, JsValue)]) e
     throw new Exception("Cannot add a value on an object without a key, malformed JSON object!")
 }
 
-private[jackson] class JsValueDeserializer(factory: TypeFactory, klass: Class[_], jsonConfig: JsonConfig)
+private[jackson] class JsValueDeserializer(factory: TypeFactory, klass: Class[?], jsonConfig: JsonConfig)
     extends JsonDeserializer[Object] {
   override def isCachable: Boolean = true
 

--- a/play-json/shared/src/main/scala-2.13+/play/api/libs/json/MapWrites.scala
+++ b/play-json/shared/src/main/scala-2.13+/play/api/libs/json/MapWrites.scala
@@ -8,13 +8,13 @@ import scala.collection.IterableOps
 import scala.collection.MapOps
 
 object MapWrites {
-  type Map[K, V] = MapOps[K, V, CC, _]
+  type Map[K, V] = MapOps[K, V, CC, ?]
 
   // see scala.collection.AnyConstr
   private[json] type AnyConstr[X] = Any
 
   // see scala.collections.MapOps
-  private[json] type CC[X, +Y] = IterableOps[_, AnyConstr, _]
+  private[json] type CC[X, +Y] = IterableOps[?, AnyConstr, ?]
 
   /**
    * Serializer for Map[String,V] types.

--- a/play-json/shared/src/main/scala-2/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala-2/play/api/libs/json/JsMacroImpl.scala
@@ -171,7 +171,7 @@ class JsMacroImpl(val c: blackbox.Context) {
         selfRef: Boolean
     )
 
-    val optTpeCtor  = typeOf[Option[_]].typeConstructor
+    val optTpeCtor  = typeOf[Option[?]].typeConstructor
     val forwardName = TermName(c.freshName("forward"))
     val configName  = TermName(c.freshName("config"))
 
@@ -581,8 +581,8 @@ class JsMacroImpl(val c: blackbox.Context) {
 
     // --- Sub implementations
 
-    val readsType  = c.typeOf[Reads[_]]
-    val writesType = c.typeOf[Writes[_]]
+    val readsType  = c.typeOf[Reads[?]]
+    val writesType = c.typeOf[Writes[?]]
 
     def macroSealedFamilyImpl(subTypes: List[Type]): c.Expr[M[A]] = {
       if (subTypes.isEmpty) {

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsConstraints.scala
@@ -138,10 +138,10 @@ trait ConstraintReads {
   def filter[A](otherwise: JsonValidationError)(p: A => Boolean)(implicit reads: Reads[A]) =
     Reads[A](js => reads.reads(js).filter(JsError(otherwise))(p))
 
-  def minLength[M](m: Int)(implicit reads: Reads[M], p: M => scala.collection.Iterable[_]) =
+  def minLength[M](m: Int)(implicit reads: Reads[M], p: M => scala.collection.Iterable[?]) =
     filterNot[M](JsonValidationError("error.minLength", m))(p(_).size < m)
 
-  def maxLength[M](m: Int)(implicit reads: Reads[M], p: M => scala.collection.Iterable[_]) =
+  def maxLength[M](m: Int)(implicit reads: Reads[M], p: M => scala.collection.Iterable[?]) =
     filterNot[M](JsonValidationError("error.maxLength", m))(p(_).size > m)
 
   /**
@@ -163,7 +163,7 @@ trait ConstraintReads {
   def verifying[A](cond: A => Boolean)(implicit rds: Reads[A]) =
     filter[A](JsonValidationError("error.invalid"))(cond)(rds)
 
-  def verifyingIf[A](cond: A => Boolean)(subreads: Reads[_])(implicit rds: Reads[A]) =
+  def verifyingIf[A](cond: A => Boolean)(subreads: Reads[?])(implicit rds: Reads[A]) =
     Reads[A] { js =>
       rds.reads(js).flatMap { t =>
         scala.util.control.Exception

--- a/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
@@ -288,9 +288,9 @@ trait LowPriorityDefaultReads extends EnvReads {
           }: JsResult[Builder[A, F[A]]]) { case (acc, (elem, idx)) =>
             (acc, ra.reads(elem)) match {
               case (JsSuccess(vs, _), JsSuccess(v, _)) => JsSuccess(vs += v)
-              case (_: JsSuccess[_], jsError: JsError) => jsError.repath(JsPath(idx))
+              case (_: JsSuccess[?], jsError: JsError) => jsError.repath(JsPath(idx))
               case (JsError(errors0), JsError(errors)) => JsError(errors0 ++ JsResult.repath(errors, JsPath(idx)))
-              case (jsError: JsError, _: JsSuccess[_]) => jsError
+              case (jsError: JsError, _: JsSuccess[?]) => jsError
             }
           }
           .map(_.result())
@@ -557,7 +557,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
         (acc, result) match {
           case (Right(vs), JsSuccess(v, _)) => Right(vs + v)
           case (Right(_), JsError(e))       => Left(locate(e, key))
-          case (Left(e), _: JsSuccess[_])   => Left(e)
+          case (Left(e), _: JsSuccess[?])   => Left(e)
           case (Left(e1), JsError(e2))      => Left(e1 ++ locate(e2, key))
         }
       }.fold(JsError.apply, res => JsSuccess(res))


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes


## Purpose



## Background Context

old wildcard syntax `[_]` is deprecated in latest Scala 3.

```
Welcome to Scala 3.6.3 (21.0.5, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                           
scala> val a: List[_] = Nil
1 warning found
-- Warning: --------------------------------------------------------------------
1 |val a: List[_] = Nil
  |            ^
  |        `_` is deprecated for wildcard arguments of types: use `?` instead
val a: List[?] = List()
                                                                                                                                           
scala> val b: List[?] = Nil
val b: List[?] = List()
```

## References

