### PR TITLE
For information / discussion: Add support for Scala 3 enums

### DIFF
--- a/play-json/shared/src/main/scala-3/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/JsMacroImpl.scala
@@ -241,8 +241,12 @@ object JsMacroImpl { // TODO: debug
                   TypeRepr.of[String]
                 )
 
+                val termSym = tpr.termSymbol
+                val typeSym = tpr.typeSymbol
+                val isCase = termSym.flags.is(Flags.Case)
+
                 val tpeCaseName: Expr[String] = '{
-                  ${ config }.typeNaming(${ Expr(typeName(tpr.typeSymbol)) })
+                  ${ config }.typeNaming(${ Expr(typeName(if isCase then termSym else typeSym)) })
                 }
 
                 val resolve = resolver[Reads, sub](
@@ -595,8 +599,12 @@ object JsMacroImpl { // TODO: debug
                   subTpr
                 )
 
+                val termSym = tpr.termSymbol
+                val typeSym = tpr.typeSymbol
+                val isCase = termSym.flags.is(Flags.Case)
+
                 val tpeCaseName: Expr[String] = '{
-                  ${ config }.typeNaming(${ Expr(typeName(tpr.typeSymbol)) })
+                  ${ config }.typeNaming(${ Expr(typeName(if isCase then termSym else typeSym)) })
                 }
 
                 val resolve = resolver[Writes, sub](

--- a/play-json/shared/src/test/scala-3/play/api/libs/json/MacroScala3Spec.scala
+++ b/play-json/shared/src/test/scala-3/play/api/libs/json/MacroScala3Spec.scala
@@ -4,12 +4,14 @@
 
 package play.api.libs.json
 
+import org.scalatest.EitherValues
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 final class MacroScala3Spec
     extends AnyWordSpec
     with Matchers
+    with EitherValues
     with org.scalatestplus.scalacheck.ScalaCheckPropertyChecks {
   "Case class" should {
     "not be handled" when {
@@ -57,6 +59,44 @@ final class MacroScala3Spec
       }
     }
   }
+
+  "Scala 3 enum" should {
+    "be handled" when {
+      "declared with no-arg cases" in {
+        given Format[Color.Red.type]   = Json.format[Color.Red.type]
+        given Format[Color.Green.type] = Json.format[Color.Green.type]
+        given Format[Color.Blue.type]  = Json.format[Color.Blue.type]
+        val format                     = Json.format[Color]
+
+        val redJson = Json.obj("_type" -> "play.api.libs.json.Color.Red")
+        format.writes(Color.Red).mustEqual(redJson)
+        format.reads(redJson).asEither.value.mustEqual(Color.Red)
+
+        val greenJson = Json.obj("_type" -> "play.api.libs.json.Color.Green")
+        format.writes(Color.Green).mustEqual(greenJson)
+        format.reads(greenJson).asEither.value.mustEqual(Color.Green)
+
+        val blueJson = Json.obj("_type" -> "play.api.libs.json.Color.Blue")
+        format.writes(Color.Blue).mustEqual(blueJson)
+        format.reads(blueJson).asEither.value.mustEqual(Color.Blue)
+      }
+    }
+
+    "declared with single-arg case" in {
+      given Format[IntOption.Some] = Json.format[IntOption.Some]
+      given Format[IntOption.None.type] = Json.format[IntOption.None.type]
+      given format: Format[IntOption] = Json.format[IntOption]
+
+      val someValue = IntOption.Some(1)
+      val someJson = Json.obj("_type" -> "play.api.libs.json.IntOption.Some", "value" -> 1)
+      format.writes(someValue).mustEqual(someJson)
+      format.reads(someJson).asEither.value.mustEqual(someValue)
+
+      val noneJson = Json.obj("_type" -> "play.api.libs.json.IntOption.None")
+      format.writes(IntOption.None).mustEqual(noneJson)
+      format.reads(noneJson).asEither.value.mustEqual(IntOption.None)
+    }
+  }
 }
 
 final class CustomNoProductOf(val name: String, val age: Int)
@@ -65,4 +105,13 @@ object CustomNoProductOf {
 
   given Conversion[CustomNoProductOf, Tuple2[String, Int]] =
     (v: CustomNoProductOf) => v.name -> v.age
+}
+
+enum Color {
+  case Red, Green, Blue
+}
+
+enum IntOption {
+  case Some(value: Int)
+  case None
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #1017.

However, it does so using Scala 3's [Mirror.Sum](https://docs.scala-lang.org/scala3/reference/contextual/derivation.html). This forbids any subclasses which are not products or sums themselves.

This is why the test for `knownSubclasses` is failing - `TestUnion.UT` has a subclass `UC` which is a normal class.

## Purpose

This PR adds support for Scala 3 `enum`s.

## Background Context

The problem with the current implementation is that it assumes that the `.children` of a `TypeRepr` will be subclasses of that `TypeRepr`.

Scala 3 `enum` `case`s are encoded as `val`s which are bound to an anonymous class. They are ascribed with the type of the parent definition.

For example:

```scala
enum Color {
  case Red, Green, Blue
}

// Color.Red is encoded as ===>

val Red: Color = $new(0, "Red")
```

This causes the `subclasses` function of the `knownSubclasses` helper to loop indefinitely trying to find the subclasses of `Color` because the `tpt.tpe` of the `ValDef` children is the same `TypeRepr` for `Color` that we started with. This is the cause for #1019.

I do not know how to get the singleton `TypeRepr` of the `enum` `case` from the `ValDef`, but I think that would be the way to solve this problem while preserving the existing behaviour of the macro.

## References

[Scala 3 Enumerations Implementation](https://docs.scala-lang.org/scala3/reference/enums/enums.html#implementation)
