### PR TITLE
Make JacksonJson `private[play]` so we can use it in Play

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -284,7 +284,7 @@ private[json] object JacksonJson {
   private[json] def get: JacksonJson = instance
 }
 
-private[json] case class JacksonJson(jsonConfig: JsonConfig) {
+private[play] case class JacksonJson(jsonConfig: JsonConfig) {
   private val jsonFactory = new JsonFactoryBuilder()
     .streamReadConstraints(jsonConfig.streamReadConstraints)
     .build()


### PR DESCRIPTION
/cc @pjfanning 

I don't think there is the need to do the same for the companion object (?)