### PR TITLE
support Jackson StreamWriteConstraints

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -279,6 +279,7 @@ private[json] object JacksonJson {
 private[play] case class JacksonJson(jsonConfig: JsonConfig) {
   private val jsonFactory = new JsonFactoryBuilder()
     .streamReadConstraints(jsonConfig.streamReadConstraints)
+    .streamWriteConstraints(jsonConfig.streamWriteConstraints)
     .build()
   private val mapper = JsonMapper
     .builder(jsonFactory)

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonConfigSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonConfigSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import com.fasterxml.jackson.core.{ StreamReadConstraints, StreamWriteConstraints }
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class JsonConfigSpec extends AnyWordSpec with Matchers {
+  "JsonConfig" should {
+    "fetch default nesting depth (parsing)" in {
+      JsonConfig.defaultStreamReadConstraints.getMaxNestingDepth.mustEqual(StreamReadConstraints.DEFAULT_MAX_DEPTH)
+    }
+    "fetch default nesting depth (serializer)" in {
+      JsonConfig.defaultStreamWriteConstraints.getMaxNestingDepth.mustEqual(StreamWriteConstraints.DEFAULT_MAX_DEPTH)
+    }
+    "override nesting depth (parsing)" in {
+      System.setProperty(JsonConfig.maxNestingDepth, "200")
+      try {
+        JsonConfig.loadMaxNestingDepth.mustEqual(200)
+      } finally {
+        System.clearProperty(JsonConfig.maxNestingDepth)
+      }
+    }
+    "override nesting depth (serializer)" in {
+      System.setProperty(JsonConfig.maxSerializerNestingDepth, "300")
+      try {
+        JsonConfig.loadMaxSerializerNestingDepth.mustEqual(300)
+      } finally {
+        System.clearProperty(JsonConfig.maxSerializerNestingDepth)
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

- Fixes #1205

## Purpose

I repurposed the system property for maxNestingDepth to cover read and write cases.
I renamed the property to `play.json.maxNestingDepth` (it is a recently added property so it is ok to rename it)

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
