### PR TITLE
[2.10.x] Avoid running out of memory when parsing heavily nested arrays or objects

### DIFF
--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -511,5 +511,62 @@ class JsonSpec extends org.specs2.mutable.Specification {
       parsed.asInstanceOf[JsObject].fields.mustEqual(original.fields)
       Json.stringify(parsed).mustEqual(originalString)
     }
+
+    "allow parsing objects nested up to max depth" in {
+      try {
+        val depth = 1000
+        Json.parse(("{\"obj\":" * depth) + "1" + ("}" * depth))
+      } catch {
+        case _: StackOverflowError =>
+          ko("StackOverflowError thrown")
+        case _: OutOfMemoryError =>
+          ko("OutOfMemoryError thrown")
+      }
+      ok
+    }
+
+    "disallow parsing nested objects exceeding max depth" in {
+      val depth = 1001
+      Json
+        .parse(("{\"obj\":" * depth) + "1" + ("}" * depth))
+        .must(throwA[IllegalArgumentException].like { case e: IllegalArgumentException =>
+          e.getMessage.must(equalTo("Document nesting depth exceeds the maximum allowed (1000)."))
+        })
+    }
+
+    "allow parsing heavily nested mixed arrays and objects" in {
+      try {
+        val depth = 1000 - 2 // in the string two open objects { are hardcoded
+        Json.parse("{\"foo\":  {\"arr\":" + ("[" * depth) + "1" + ("]" * depth) + "}}")
+      } catch {
+        case _: StackOverflowError =>
+          ko("StackOverflowError thrown")
+        case _: OutOfMemoryError =>
+          ko("OutOfMemoryError thrown")
+      }
+      ok
+    }
+
+    "disallow parsing heavily nested mixed arrays and objects" in {
+      val depth = 1001 - 2 // in the string two open objects { are hardcoded
+      Json
+        .parse("{\"foo\":  {\"arr\":" + ("[" * depth) + "1" + ("]" * depth) + "}}")
+        .must(throwA[IllegalArgumentException].like { case e: IllegalArgumentException =>
+          e.getMessage.must(equalTo("Document nesting depth exceeds the maximum allowed (1000)."))
+        })
+    }
+  }
+
+  "allow parsing many non-nested arrays and objects, not relevant for depth check" in {
+    try {
+      val repeat = 9999 // 10 thousand in total
+      Json.parse("{\"foo\": [" + ("{\"arr\":[1]}," * repeat) + "{\"arr\":[1]}]}")
+    } catch {
+      case _: StackOverflowError =>
+        ko("StackOverflowError thrown")
+      case _: OutOfMemoryError =>
+        ko("OutOfMemoryError thrown")
+    }
+    ok
   }
 }


### PR DESCRIPTION
Just like Jackson 2.15+ we restrict the maximum allowed number of nested arrays or objects (or mixed) to 1000. ~Currently this limit is hardcoded, unlike Jackson, which allows to configure it.~ (we have sys property now, just like in the main branch as of #1072) 1000 should be enough for most real world use cases. We can still make it configurable later.

Note this is about `OutOfMemoryError`'s, not about `StackOverflowError`'s. `StackOverflowError`'s are not a problem since we use a `@tailrec` optimized method. Therefore this fix is not 100% about CVE-2025-52999 (which in theory we do not run into) but just an additional precaution.

See 
- #1225 
(however, again, technically we are not affected by that CVE, since it's about running out of stack. However in theory a bad actor _could_ make an app run out of memory so it's more or less the same - if that bad actor bypasses any other security measurements, like max content size, any body parser max buffers, etc. )