### PR TITLE
Fix flaky tests

### DIFF
--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -18,6 +18,9 @@ import play.api.libs.json.Json._
 import play.api.libs.json.jackson.JacksonJson
 
 class JsonSpec extends org.specs2.mutable.Specification {
+
+  sequential
+
   "JSON".title
 
   import java.text.SimpleDateFormat


### PR DESCRIPTION
Should hopefully avoid failures like

```
[error]       x preserve a single trailing zero decimal from multiple of ten with preserveZeroDecimal=true (25 ms)
[error]        '10' != '10.0' (JsonSpec.scala:362)
```

It's always another test that fails. Likely because each tests sets the static config:
https://github.com/playframework/play-json/blob/43eb60ed950c4e067a8eeffaa09f053ea91fb0e9/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala#L88-L97

:crossed_fingers: 

Last failing workflow: https://github.com/playframework/play-json/actions/runs/18400241471/job/52429804535