### PR TITLE
Adjust jackson config

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -295,6 +295,10 @@ private[play] case class JacksonJson(jsonConfig: JsonConfig) {
       new DefaultScalaModule(),
       new PlayJsonMapperModule(jsonConfig),
     )
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+    .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
     .build()
 
   private[play] def setObjectMapper(mapper: ObjectMapper): Unit = {


### PR DESCRIPTION
Just like #1250 these configs should not interfere with `JsValue` de-/serialization.
Actually disabling `WRITE_XXX_AS_TIMESTAMPS` configs now brings the objectmapper on par with how [`EnvWrites` ](https://github.com/playframework/play-json/blob/3.0.6/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala), which, for example, by default writes `LocalDateTime` in the format `2011-12-03T10:15:30` (and not a number of milliseconds, which is the default in jackson - until Jackson 3 ;) See this test for example: https://github.com/playframework/play-json/blob/3.0.6/play-json/jvm/src/test/scala/play/api/libs/json/WritesSpec.scala#L46-L52

Same for `SerializationFeature.FAIL_ON_EMPTY_BEANS` and `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES`:
Neither does `JsValue` serialization fail when a class is empty, nor does it fail if deserializing unkown properties (tested locally as well).

The reason I am adding this configs, is the same as in #1250:
I want to make the play-json objectmapper the fallback objectmapper for play and for play-ws.

Currently Play's deprecated `newDefaultMapper` disables those settings: https://github.com/playframework/playframework/blob/3.0.9/core/play/src/main/java/play/libs/Json.java#L47-L49
So does the pekko provided object mapper: https://github.com/apache/pekko/blob/v1.2.1/serialization-jackson/src/main/resources/reference.conf#L78-L93

By doing the same here, we can then just use the play-json objectmapper in Play.