### PR TITLE
`minPlain` and `maxPlain` values are inclusive

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -86,7 +86,7 @@ private[jackson] class JsValueSerializer(jsonConfig: JsonConfig) extends JsonSer
         // configuration is ignored when called from ObjectMapper.valueToTree
         val shouldWritePlain = {
           val va = v.abs
-          va < jsonConfig.bigDecimalSerializerConfig.maxPlain && va > jsonConfig.bigDecimalSerializerConfig.minPlain
+          va <= jsonConfig.bigDecimalSerializerConfig.maxPlain && va >= jsonConfig.bigDecimalSerializerConfig.minPlain
         }
         val stripped = stripTrailingZeros(v.bigDecimal)
         val raw      = if (shouldWritePlain) stripped.toPlainString else stripped.toString


### PR DESCRIPTION
The max/min values itself are also "ok".

https://github.com/playframework/play-json/blob/0d6505cf4afa3b1539d7a9e2a65a94735fdb1395/play-json/jvm/src/main/scala/play/api/libs/json/JsonConfig.scala#L62-L74