### PR TITLE
`StreamReadConstraints` can use same digits limit like play-json internally uses

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/JsonConfig.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/JsonConfig.scala
@@ -216,7 +216,7 @@ object JsonConfig {
       .builder()
       .maxNestingDepth(loadMaxNestingDepth)
       .maxStringLength(loadMaxStringLength)
-      .maxNumberLength(Int.MaxValue) // play-json has its own support for limiting number length
+      .maxNumberLength(loadDigitsLimit) // play-json has its own support for limiting number length
       .build()
 
   private[json] val defaultStreamWriteConstraints: StreamWriteConstraints =

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -429,11 +429,29 @@ class JsonSpec extends org.specs2.mutable.Specification {
         }
 
         "fail when exceeding the number of digits limit for positive numbers" in {
-          Json.parse(invalidJsonExceedingNumberOfDigits).as[BigNumbers].must(throwA[IllegalArgumentException])
+          Json
+            .parse(invalidJsonExceedingNumberOfDigits)
+            .as[BigNumbers]
+            .must(throwA[StreamConstraintsException].like { case e: StreamConstraintsException =>
+              e.getMessage.must(
+                equalTo(
+                  "Number value length (1000000) exceeds the maximum allowed (310, from `StreamReadConstraints.getMaxNumberLength()`)"
+                )
+              )
+            })
         }
 
         "fail when exceeding the number of digits limit for negative numbers" in {
-          Json.parse(invalidJsonExceedingNumberOfDigitsNegative).as[BigNumbers].must(throwA[IllegalArgumentException])
+          Json
+            .parse(invalidJsonExceedingNumberOfDigitsNegative)
+            .as[BigNumbers]
+            .must(throwA[StreamConstraintsException].like { case e: StreamConstraintsException =>
+              e.getMessage.must(
+                equalTo(
+                  "Number value length (1000000) exceeds the maximum allowed (310, from `StreamReadConstraints.getMaxNumberLength()`)"
+                )
+              )
+            })
         }
       }
     }


### PR DESCRIPTION
We can avoid `Int.MaxValue` here.

In play-json itself we check the input's string length:
https://github.com/playframework/play-json/blob/0d6505cf4afa3b1539d7a9e2a65a94735fdb1395/play-json/jvm/src/main/scala/play/api/libs/json/BigDecimalParser.scala#L14-L15
https://github.com/playframework/play-json/blob/0d6505cf4afa3b1539d7a9e2a65a94735fdb1395/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala#L729-L731


In Jackson, it's basically doing the same:
* https://github.com/FasterXML/jackson-core/blob/jackson-core-2.20.1/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java#L537-L577 
  * ➡️https://github.com/FasterXML/jackson-core/blob/jackson-core-2.20.1/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java#L523
  * ➡️https://github.com/FasterXML/jackson-core/blob/jackson-core-2.20.1/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java#L607
  * ➡️https://github.com/FasterXML/jackson-core/blob/jackson-core-2.20.1/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java#L592

Therefore we can just sync the limit and just use the one supplied by play-json.