### PR TITLE
🧹 chore: upgrade to Jackson 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,19 +21,12 @@ def specs2(scalaVersion: String) =
     ("org.specs2" %% s"specs2-$n" % "4.23.0") % Test
   }
 
-val jacksonDatabindVersion = "2.20.1"
-val jacksonDatabind        = Seq(
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
-)
-
-val jacksonVersion = jacksonDatabindVersion
+val jacksonVersion = "3.0.3"
 val jacksons       = Seq(
-  "com.fasterxml.jackson.core"     % "jackson-core",
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310",
-  "com.fasterxml.jackson.module"   % "jackson-module-parameter-names",
-  "com.fasterxml.jackson.module"  %% "jackson-module-scala",
-).map(_ % jacksonVersion) ++ jacksonDatabind
+  "tools.jackson.core"    % "jackson-core",
+  "tools.jackson.core"    % "jackson-databind",
+  "tools.jackson.module" %% "jackson-module-scala",
+).map(_ % jacksonVersion)
 
 val joda = Seq(
   "joda-time" % "joda-time" % "2.14.0"

--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvReads.scala
@@ -26,9 +26,9 @@ import java.util.Locale
 
 import scala.util.control.NonFatal
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.databind.node.ObjectNode
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ArrayNode
+import tools.jackson.databind.node.ObjectNode
 
 import play.api.libs.json.jackson.JacksonJson
 

--- a/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/EnvWrites.scala
@@ -18,7 +18,7 @@ import java.time.ZonedDateTime
 import java.time.{ Duration => JDuration }
 import java.util.Locale
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 import play.api.libs.json.jackson.JacksonJson
 
 trait EnvWrites {

--- a/play-json/jvm/src/main/scala/play/api/libs/json/JsonConfig.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/JsonConfig.scala
@@ -4,8 +4,8 @@
 
 package play.api.libs.json
 
-import com.fasterxml.jackson.core.StreamReadConstraints
-import com.fasterxml.jackson.core.StreamWriteConstraints
+import tools.jackson.core.StreamReadConstraints
+import tools.jackson.core.StreamWriteConstraints
 
 import play.api.libs.json.JsonConfig.defaultMaxPlain
 import play.api.libs.json.JsonConfig.defaultMinPlain

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonConfigSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonConfigSpec.scala
@@ -4,7 +4,7 @@
 
 package play.api.libs.json
 
-import com.fasterxml.jackson.core.{ StreamReadConstraints, StreamWriteConstraints }
+import tools.jackson.core.{ StreamReadConstraints, StreamWriteConstraints }
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #1258

## Purpose

Upgrade Jackson from 2.x to 3.x.

## Background Context

- `build.sbt`: I merged declaration of `jackson-databind` with the other Jackson dependencies, not sure why it was separate but there doesn't seem to be any reason anymore
- `JacksonJson`:
  - I had to change `ObjectMapper` to `JsonMapper` so that we can use `.enable(JsonWriteFeature.ESCAPE_NON_ASCII)` (not available on `ObjectMapper` as it's a JSON specific feature). This makes sense anyway IMHO _but_ it'll be a source breaking change for users of `setObjectMapper` (Play Framework?)
  - `generateFromJsValue` rebuild a new `JsonMapper` at each call, this is very likely not optimal. We could store an instance of mapper with the proper escapeNonAscii configuration in addition to the already stored mapper.
  - removed `createGenerator`, they don't bring value since we're writing a single value and they duplicated some configuration (escapeNonAscii, pretty printer)
  - `serialize` method for `JsNumber`: for some reason, Jackson `JsonGenerator.writeNumber(String)` now writes the number as a string (with extra quotes), at least it what's the [`TreeBuildingGenerator` implementation actually used does](https://github.com/FasterXML/jackson-databind/blob/f946c3d8db48fabe514a912d9dec856d0f659f97/src/main/java/tools/jackson/databind/node/TreeBuildingGenerator.java#L408), this was visible in `JsonSpec` tests. In order to workaround that, I had to use `writeNumber(BigDecimal)` instead but this means an extra `BigDecimal` allocation.
    - When looking at other implementations of `JsonGenerator.writeNumber(String)`, I wonder if this the `TreeBuildingGenerator` implementation is really expected: others do write as a "raw" number.
    - ~~I couldn't find a change in 3.x that explains this behaviour change though. The implementations in Jackson are like this for quite some time already.~~ EDIT: this is actually caused by the removal of `createGenerator` steps, it was previously using the [`WriterBasedJsonGenerator` implementation](https://github.com/FasterXML/jackson-core/blob/0406a51a186125a451e3353ee1824f9a0407b152/src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java#L921)
- `JsonSpec`: added assertions on the resulting type when deserializing from `JsValue` (Play JSON) to `JsonNode` (Jackson) to better cover the intent of the test cases. Asserting only on the string representation is quite risky (I actually had a working implementation where the string representation was good but the Jackson nodes were not making sense).
- 3 modules are now included by default in Jackson: `ParameterNamesModule`, `Jdk8Module`, `JavaTimeModule`, hence we no longer need to enable them explicitly (we couldn't anyway)

## Remaining work

- [ ] Decide if it's best to optimize `generateFromJsValue` to not rebuild a new `JsonMapper` each time
- [ ] Refine/rediscuss the changes around `JsNumber` serialization and `JsonGenerator.writeNumber(String)`
- [ ] Open issue and PR in play-framework to adapt the usage of `setObjectMapper`

## References

- https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md
