### PR TITLE
Simplify and optimize prettyPrint and stringify methods

### DIFF
--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -281,54 +281,35 @@ private[play] object JacksonJson {
 }
 
 private[play] case class JacksonJson(defaultMapperJsonConfig: JsonConfig) {
-  private var currentMapper: ObjectMapper                   = null
-  private var currentMapperWithEscapeNonAscii: ObjectMapper = null
+  private var currentMapper: ObjectMapper = null
+  private val defaultMapper: ObjectMapper = JsonMapper
+    .builder(
+      new JsonFactoryBuilder()
+        .streamReadConstraints(defaultMapperJsonConfig.streamReadConstraints)
+        .streamWriteConstraints(defaultMapperJsonConfig.streamWriteConstraints)
+        .build()
+    )
+    .addModules(
+      new ParameterNamesModule(),
+      new Jdk8Module(),
+      new JavaTimeModule(),
+      new DefaultScalaModule(),
+      new PlayJsonMapperModule(defaultMapperJsonConfig),
+    )
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+    .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+    .build()
 
-  private val defaultMapper: ObjectMapper                   = buildMapper(false)
-  private val defaultMapperWithEscapeNonAscii: ObjectMapper = buildMapper(true)
-
-  private def buildMapper(escapeNonAscii: Boolean): ObjectMapper = {
-    JsonMapper
-      .builder(
-        new JsonFactoryBuilder()
-          .streamReadConstraints(defaultMapperJsonConfig.streamReadConstraints)
-          .streamWriteConstraints(defaultMapperJsonConfig.streamWriteConstraints)
-          .build()
-      )
-      .addModules(
-        new ParameterNamesModule(),
-        new Jdk8Module(),
-        new JavaTimeModule(),
-        new DefaultScalaModule(),
-        new PlayJsonMapperModule(defaultMapperJsonConfig),
-      )
-      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-      .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-      .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
-      .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-      .configure(JsonWriteFeature.ESCAPE_NON_ASCII, escapeNonAscii)
-      .build()
-  }
-
-  private[play] def mapper(escapeNonAscii: Boolean = false): ObjectMapper = {
-    if (escapeNonAscii) {
-      if (currentMapperWithEscapeNonAscii == null) {
-        defaultMapperWithEscapeNonAscii
-      } else {
-        currentMapperWithEscapeNonAscii
-      }
-    } else {
-      if (currentMapper == null) {
-        defaultMapper
-      } else {
-        currentMapper
-      }
-    }
+  private[play] def mapper(): ObjectMapper = if (currentMapper == null) {
+    defaultMapper
+  } else {
+    currentMapper
   }
 
   private[play] def setObjectMapper(mapper: ObjectMapper): Unit = {
     this.currentMapper = mapper
-    this.currentMapperWithEscapeNonAscii = mapper.copy().enable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature)
   }
 
   def parseJsValue(data: Array[Byte]): JsValue =
@@ -340,8 +321,16 @@ private[play] case class JacksonJson(defaultMapperJsonConfig: JsonConfig) {
   def parseJsValue(stream: InputStream): JsValue =
     mapper().readValue(stream, classOf[JsValue])
 
-  def generateFromJsValue(jsValue: JsValue, escapeNonASCII: Boolean): String =
-    mapper(escapeNonASCII).writeValueAsString(jsValue)
+  def generateFromJsValue(jsValue: JsValue, escapeNonASCII: Boolean): String = {
+    val writer           = mapper().writer()
+    val configuredWriter = if (escapeNonASCII) {
+      writer.`with`(JsonWriteFeature.ESCAPE_NON_ASCII)
+    } else {
+      writer
+    }
+
+    configuredWriter.writeValueAsString(jsValue)
+  }
 
   def prettyPrint(jsValue: JsValue): String = {
     val writer: ObjectWriter = mapper().writerWithDefaultPrettyPrinter()

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -6,7 +6,6 @@ package play.api.libs.json.jackson
 
 import java.io.InputStream
 import java.io.OutputStream
-import java.io.StringWriter
 
 import scala.annotation.switch
 import scala.annotation.tailrec
@@ -20,7 +19,6 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonTokenId
 import com.fasterxml.jackson.core.Version
 import com.fasterxml.jackson.core.json.JsonWriteFeature
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 
 import com.fasterxml.jackson.databind.Module.SetupContext
 import com.fasterxml.jackson.databind._
@@ -283,42 +281,55 @@ private[play] object JacksonJson {
 }
 
 private[play] case class JacksonJson(defaultMapperJsonConfig: JsonConfig) {
-  private var currentMapper: ObjectMapper = null
-  private val defaultMapper: ObjectMapper = JsonMapper
-    .builder(
-      new JsonFactoryBuilder()
-        .streamReadConstraints(defaultMapperJsonConfig.streamReadConstraints)
-        .streamWriteConstraints(defaultMapperJsonConfig.streamWriteConstraints)
-        .build()
-    )
-    .addModules(
-      new ParameterNamesModule(),
-      new Jdk8Module(),
-      new JavaTimeModule(),
-      new DefaultScalaModule(),
-      new PlayJsonMapperModule(defaultMapperJsonConfig),
-    )
-    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-    .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
-    .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-    .build()
+  private var currentMapper: ObjectMapper                   = null
+  private var currentMapperWithEscapeNonAscii: ObjectMapper = null
 
-  private[play] def mapper(): ObjectMapper = if (currentMapper == null) {
-    defaultMapper
-  } else {
-    currentMapper
+  private val defaultMapper: ObjectMapper                   = buildMapper(false)
+  private val defaultMapperWithEscapeNonAscii: ObjectMapper = buildMapper(true)
+
+  private def buildMapper(escapeNonAscii: Boolean): ObjectMapper = {
+    JsonMapper
+      .builder(
+        new JsonFactoryBuilder()
+          .streamReadConstraints(defaultMapperJsonConfig.streamReadConstraints)
+          .streamWriteConstraints(defaultMapperJsonConfig.streamWriteConstraints)
+          .build()
+      )
+      .addModules(
+        new ParameterNamesModule(),
+        new Jdk8Module(),
+        new JavaTimeModule(),
+        new DefaultScalaModule(),
+        new PlayJsonMapperModule(defaultMapperJsonConfig),
+      )
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+      .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+      .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+      .configure(JsonWriteFeature.ESCAPE_NON_ASCII, escapeNonAscii)
+      .build()
+  }
+
+  private[play] def mapper(escapeNonAscii: Boolean = false): ObjectMapper = {
+    if (escapeNonAscii) {
+      if (currentMapperWithEscapeNonAscii == null) {
+        defaultMapperWithEscapeNonAscii
+      } else {
+        currentMapperWithEscapeNonAscii
+      }
+    } else {
+      if (currentMapper == null) {
+        defaultMapper
+      } else {
+        currentMapper
+      }
+    }
   }
 
   private[play] def setObjectMapper(mapper: ObjectMapper): Unit = {
     this.currentMapper = mapper
+    this.currentMapperWithEscapeNonAscii = mapper.copy().enable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature)
   }
-
-  private def stringJsonGenerator(out: StringWriter) =
-    mapper().getFactory.createGenerator(out)
-
-  private def stringJsonGenerator(out: OutputStream) =
-    mapper().getFactory.createGenerator(out)
 
   def parseJsValue(data: Array[Byte]): JsValue =
     mapper().readValue(data, classOf[JsValue])
@@ -329,53 +340,17 @@ private[play] case class JacksonJson(defaultMapperJsonConfig: JsonConfig) {
   def parseJsValue(stream: InputStream): JsValue =
     mapper().readValue(stream, classOf[JsValue])
 
-  private def withStringWriter[T](f: StringWriter => T): T = {
-    val sw = new StringWriter()
-
-    try {
-      f(sw)
-    } catch {
-      case err: Throwable => throw err
-    } finally {
-      if (sw != null) try {
-        sw.close()
-      } catch {
-        case _: Throwable => ()
-      }
-    }
-  }
-
   def generateFromJsValue(jsValue: JsValue, escapeNonASCII: Boolean): String =
-    withStringWriter { sw =>
-      val gen = stringJsonGenerator(sw)
+    mapper(escapeNonASCII).writeValueAsString(jsValue)
 
-      if (escapeNonASCII) {
-        gen.enable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature)
-      }
-
-      mapper().writeValue(gen, jsValue)
-      sw.flush()
-      sw.getBuffer.toString
-    }
-
-  def prettyPrint(jsValue: JsValue): String = withStringWriter { sw =>
-    val gen = stringJsonGenerator(sw).setPrettyPrinter(
-      new DefaultPrettyPrinter()
-    )
+  def prettyPrint(jsValue: JsValue): String = {
     val writer: ObjectWriter = mapper().writerWithDefaultPrettyPrinter()
-
-    writer.writeValue(gen, jsValue)
-    sw.flush()
-    sw.getBuffer.toString
+    writer.writeValueAsString(jsValue)
   }
 
   def prettyPrintToStream(jsValue: JsValue, stream: OutputStream): Unit = {
-    val gen = stringJsonGenerator(stream).setPrettyPrinter(
-      new DefaultPrettyPrinter()
-    )
     val writer: ObjectWriter = mapper().writerWithDefaultPrettyPrinter()
-
-    writer.writeValue(gen, jsValue)
+    writer.writeValue(stream, jsValue)
   }
 
   def jsValueToBytes(jsValue: JsValue): Array[Byte] =

--- a/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/play-json/jvm/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.JsonFactoryBuilder
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonTokenId
+import com.fasterxml.jackson.core.StreamWriteFeature
 import com.fasterxml.jackson.core.Version
 import com.fasterxml.jackson.core.json.JsonWriteFeature
 
@@ -338,7 +339,9 @@ private[play] case class JacksonJson(defaultMapperJsonConfig: JsonConfig) {
   }
 
   def prettyPrintToStream(jsValue: JsValue, stream: OutputStream): Unit = {
-    val writer: ObjectWriter = mapper().writerWithDefaultPrettyPrinter()
+    val writer: ObjectWriter = mapper()
+      .writerWithDefaultPrettyPrinter()
+      .without(StreamWriteFeature.AUTO_CLOSE_TARGET)
     writer.writeValue(stream, jsValue)
   }
 

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.{ ArrayNode, NumericNode, ObjectNode }
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Json._
-import play.api.libs.json.jackson.JacksonJson
+import play.api.libs.json.jackson.{ JacksonJson, PlayJsonMapperModule }
 
 class JsonSpec extends org.specs2.mutable.Specification {
 
@@ -527,6 +527,21 @@ class JsonSpec extends org.specs2.mutable.Specification {
       deserialized.map(_.isInstanceOf[NumericNode]).must_==(JsSuccess(true)) and (
         deserialized.map(_.toString).must_==(JsSuccess("12.345"))
       )
+    }
+
+    "Use a custom ObjectMapper subclass for ASCII serialization" in {
+      val jacksonJson  = JacksonJson(JsonConfig.settings)
+      val customMapper = new ObjectMapper() {}
+
+      jacksonJson.setObjectMapper(customMapper)
+      customMapper.registerModule(new PlayJsonMapperModule())
+
+      jacksonJson
+        .generateFromJsValue(JsString("é"), escapeNonASCII = true)
+        .mustEqual("\"\\u00E9\"")
+
+      jacksonJson.setObjectMapper(null)
+      jacksonJson.mapper().eq(customMapper).mustEqual(false)
     }
 
     "Serialize JsNumbers with integers correctly" in {

--- a/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/play-json/jvm/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -14,6 +14,7 @@ import java.util.TimeZone
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.{ ArrayNode, NumericNode, ObjectNode }
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Json._
 import play.api.libs.json.jackson.JacksonJson
@@ -481,36 +482,51 @@ class JsonSpec extends org.specs2.mutable.Specification {
     }
 
     "Serialize and deserialize Jackson ObjectNodes" in {
-      val on = mapper
+      val on: ObjectNode = mapper
         .createObjectNode()
         .put("foo", 1)
         .put("bar", "two")
-      val json = Json.obj("foo" -> 1, "bar" -> "two")
+      val json                             = Json.obj("foo" -> 1, "bar" -> "two")
+      val deserialized: JsResult[JsonNode] = fromJson[JsonNode](json)
 
       toJson(on).must_==(json) and (
-        fromJson[JsonNode](json).map(_.toString).must_==(JsSuccess(on.toString))
+        deserialized.map(_.isInstanceOf[ObjectNode]).must_==(JsSuccess(true))
+      ) and (
+        deserialized.map(_.toString).must_==(JsSuccess(on.toString))
       )
     }
 
     "Serialize and deserialize Jackson ArrayNodes" in {
-      val an = mapper
+      val an: ArrayNode = mapper
         .createArrayNode()
         .add("one")
         .add(2)
-      val json = Json.arr("one", 2)
+      val json                             = Json.arr("one", 2)
+      val deserialized: JsResult[JsonNode] = fromJson[JsonNode](json)
+
       toJson(an).must(equalTo(json)) and (
-        fromJson[JsonNode](json).map(_.toString).must_==(JsSuccess(an.toString))
+        deserialized.map(_.isInstanceOf[ArrayNode]).must_==(JsSuccess(true))
+      ) and (
+        deserialized.map(_.toString).must_==(JsSuccess(an.toString))
       )
     }
 
     "Deserialize integer JsNumber as Jackson number node" in {
-      val jsNum = JsNumber(new java.math.BigDecimal("50"))
-      fromJson[JsonNode](jsNum).map(_.toString).must_==(JsSuccess("50"))
+      val jsNum                            = JsNumber(new java.math.BigDecimal("50"))
+      val deserialized: JsResult[JsonNode] = fromJson[JsonNode](jsNum)
+
+      deserialized.map(_.isInstanceOf[NumericNode]).must_==(JsSuccess(true)) and (
+        deserialized.map(_.toString).must_==(JsSuccess("50"))
+      )
     }
 
     "Deserialize float JsNumber as Jackson number node" in {
-      val jsNum = JsNumber(new java.math.BigDecimal("12.345"))
-      fromJson[JsonNode](jsNum).map(_.toString).must_==(JsSuccess("12.345"))
+      val jsNum                            = JsNumber(new java.math.BigDecimal("12.345"))
+      val deserialized: JsResult[JsonNode] = fromJson[JsonNode](jsNum)
+
+      deserialized.map(_.isInstanceOf[NumericNode]).must_==(JsSuccess(true)) and (
+        deserialized.map(_.toString).must_==(JsSuccess("12.345"))
+      )
     }
 
     "Serialize JsNumbers with integers correctly" in {

--- a/play-json/shared/src/main/scala/play/api/libs/json/Json.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Json.scala
@@ -160,7 +160,7 @@ sealed trait JsonFacade {
    * writes the result to an output stream.
    *
    * $jsonParam
-   * @param stream the stream to write to.
+   * @param stream the stream to write to; it is not closed by this method.
    */
   def prettyPrintToStream(json: JsValue, stream: OutputStream): Unit
 

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonSharedSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonSharedSpec.scala
@@ -21,6 +21,17 @@ class JsonSharedSpec
     with org.scalatest.TryValues
     with org.scalatestplus.scalacheck.ScalaCheckPropertyChecks {
 
+  private class CloseTrackingOutputStream extends ByteArrayOutputStream {
+    private var closed = false
+
+    def isClosed: Boolean = closed
+
+    override def close(): Unit = {
+      closed = true
+      super.close()
+    }
+  }
+
   case class User(id: Long, name: String, friends: List[User])
 
   implicit val UserFormat: Format[User] = (
@@ -344,15 +355,16 @@ class JsonSharedSpec
 }""")
     }
 
-    "JSON pretty print to stream" in json { js =>
+    "JSON pretty print to stream without closing it" in json { js =>
       def jo = js.obj(
         "key1" -> "toto",
         "key2" -> js.obj("key21" -> "tata", "key22" -> 123),
         "key3" -> js.arr(1, "tutu")
       )
 
-      val stream = new ByteArrayOutputStream()
+      val stream = new CloseTrackingOutputStream()
       js.prettyPrintToStream(jo, stream)
+      stream.isClosed.mustEqual(false)
       stream
         .toString("UTF-8")
         .mustEqual("""{


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Purpose

This PR simplifies the code of `JacksonJson` (JVM) that is used on the path of the `Json.stringify`, `Json.asciiStringify`, `Json.prettyPrint` and `Json.prettyPrintToStream` methods.

The simplification consists of:
- removing unnecessary creation of a `JsonGenerator` at each call (`mapper.getFactory.createGenerator`)
  - this also reduces duplication, for instance the `prettyPrint` only set the `DefaultPrettyPrinter` once rather than doing it once on the `ObjectWriter` and once on the `JsonGenerator` (to be fair, I don't know if both were useful or one would have been enough anyways)
- removing unnecessary creation of a `StringWriter`: Jackson handles it itself.
  - As per Jackson's documentation:
    > `writeValueAsString`: Functionally equivalent to calling `writeValue(Writer, Object)` with `StringWriter` and constructing String, but more efficient.

On top of code simplification, this also brings performance improvements.

A minimal JMH benchmark (not included in the PR but I could if you think it's worth it) gives the following results on my laptop:

```
[info] Benchmark                                     Mode  Cnt     Score     Error   Units

[info] PrettyPrintBench.asciiStringify_before       thrpt   10   703,628 ±  18,430  ops/ms
[info] PrettyPrintBench.asciiStringify              thrpt   10  1303,345 ±  20,933  ops/ms

[info] PrettyPrintBench.stringify_before            thrpt   10   708,859 ±  14,447  ops/ms
[info] PrettyPrintBench.stringify                   thrpt   10  1316,503 ±  43,704  ops/ms

[info] PrettyPrintBench.prettyPrintToStream_before  thrpt   10   299,436 ± 134,214  ops/ms
[info] PrettyPrintBench.prettyPrintToStream         thrpt   10   952,180 ±  91,934  ops/ms

[info] PrettyPrintBench.prettyPrint_before          thrpt   10   571,337 ±  13,095  ops/ms
[info] PrettyPrintBench.prettyPrint                 thrpt   10   992,202 ±  47,259  ops/ms
```

While this is a very basic benchmark on a single case (a single `JsValue`), I think it's safe to assume that the code change improves performance.

<details>

<summary>Benchmark code</summary>

```scala

package play.api.libs.json

import org.openjdk.jmh.annotations._
import org.openjdk.jmh.util.NullOutputStream
import play.api.libs.json.jackson.JacksonJson

import java.io.OutputStream
import java.util.concurrent.TimeUnit

/**
 * ==Quick Run==
 * benchmarks / Jmh / run .*PrettyPrintBench
 *
 */
@Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
@State(Scope.Benchmark)
@BenchmarkMode(Array(Mode.Throughput))
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Fork(
  jvmArgsAppend =
    Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:-BackgroundCompilation", "-XX:-TieredCompilation"),
  value = 1
)
class PrettyPrintBench {

  private var jsObject: JsObject = _
  private var outputStream: OutputStream = _

  @Setup def setup(): Unit = {
    jsObject = Json.obj(
      "key1" -> "toto",
      "key2" -> Json.obj("key21" -> "tata", "key22" -> 123),
      "key3" -> Json.arr(1, "tutu")
    )
    outputStream = new NullOutputStream()
  }
  
  @TearDown
  def clean() = {
    outputStream.close()
  }

  @Benchmark
  def prettyPrint = {
    JacksonJson.get.prettyPrint(jsObject)
    ()
  }
  
  @Benchmark
  def stringify = {
    JacksonJson.get.generateFromJsValue(jsObject, false)
    ()
  }
  
  @Benchmark
  def asciiStringify = {
    JacksonJson.get.generateFromJsValue(jsObject, true)
    ()
  }

  @Benchmark
  def prettyPrintToStream = {
    JacksonJson.get.prettyPrintToStream(jsObject, outputStream)
    ()
  }

}
```

</details>


## Background Context

I noticed this when working on the upgrade to Jackson 3 (https://github.com/playframework/play-json/pull/1268) and I think it's worth a separate PR before any upgrade to Jackson 3.

## Additional notes

- The 1st commit may seem unrelated, I can open a dedicated PR for it if you prefer (or squash it with the 2nd). In practice it's partially related because at some point (again when working on the Jackson 3 upgrade), I was able to get tests working when comparing strings but the underlying object (Jackson `JsonNode`) was not of the right type.

- Having 2 mappers (one without and one with the `ESCAPE_NON_ASCII` feature) goes in the direction of Jackson 3 where these objects are immutable