### PR TITLE
Add `recursive` methods

### DIFF
--- a/docs/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
+++ b/docs/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
@@ -136,6 +136,29 @@ One special case that our example model doesn't demonstrate is how to handle `Re
 
 @[reads-writes-recursive](code/ScalaJsonCombinatorsSpec.scala)
 
+When defining a recursive codec with a Scala 3 `given`, use the Scala 3-only
+`recursive` method instead. It supplies the codec being constructed as a
+deferred contextual value, so codecs for recursive fields can be derived
+without referring directly to the `given` during its initialization:
+
+```scala
+final case class User(name: String, friends: List[User])
+
+given OFormat[User] = OFormat.recursive {
+  (
+    (__ \ "name").format[String] and
+      (__ \ "friends").format[List[User]]
+  )(User.apply, user => (user.name, user.friends))
+}
+```
+
+Equivalent methods are available on the `Reads`, `Writes`, `OWrites`, and
+`Format` companion objects. The deferred codec can also be accessed within
+the block using `summon[OFormat[User]]`. These methods defer codec
+initialization; they do not make reading or writing deeply recursive values
+stack-safe. Scala 2 code should continue to use the `lazyRead`, `lazyWrite`,
+and `lazyFormat` methods.
+
 ## Format
 
 [`Format[T]`](api/scala/play/api/libs/json/Format.html) is just a mix of the `Reads` and `Writes` traits and can be used for implicit conversion in place of its components.

--- a/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveFormat.scala
+++ b/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveFormat.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+trait RecursiveFormat { self: Format.type =>
+
+}

--- a/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveOFormat.scala
+++ b/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveOFormat.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+trait RecursiveOFormat { self: OFormat.type =>
+
+}

--- a/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveOWrites.scala
+++ b/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveOWrites.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+trait RecursiveOWrites { self: OWrites.type =>
+
+}

--- a/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveReads.scala
+++ b/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveReads.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+trait RecursiveReads { self: Reads.type =>
+
+}

--- a/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveWrites.scala
+++ b/play-json/shared/src/main/scala-2/play/api/libs/json/RecursiveWrites.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+trait RecursiveWrites { self: Writes.type =>
+
+}

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveFormat.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveFormat.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import scala.annotation.tailrec
+
+trait RecursiveFormat { self: Format.type =>
+  final def recursive[A](f: Format[A] ?=> Format[A]): Format[A] = {
+    lazy val res: Format[A] = f(using RecursiveFormat.DeferredFormat(() => res))
+    res
+  }
+}
+
+private[json] object RecursiveFormat {
+  private final case class DeferredFormat[A](value: () => Format[A]) extends Format[A] {
+    private lazy val resolved: Format[A] = resolve(value)
+
+    @tailrec
+    private def resolve(f: () => Format[A]): Format[A] =
+      f() match {
+        case DeferredFormat(f) =>
+          resolve(f)
+        case next =>
+          next
+      }
+
+    override def reads(json: JsValue): JsResult[A] =
+      resolved.reads(json)
+
+    override def writes(o: A): JsValue =
+      resolved.writes(o)
+  }
+}

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveFormat.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveFormat.scala
@@ -7,6 +7,19 @@ package play.api.libs.json
 import scala.annotation.tailrec
 
 trait RecursiveFormat { self: Format.type =>
+
+  /**
+   * Constructs a `Format` for a recursive type.
+   *
+   * While `f` is evaluated, a deferred `Format[A]` is available as a
+   * contextual value. This lets formats derived inside `f` refer to the
+   * resulting format without forcing it during initialization.
+   *
+   * This method is available only in Scala 3.
+   *
+   * @tparam A the type read from and written as JSON
+   * @param f function that constructs the recursive format
+   */
   final def recursive[A](f: Format[A] ?=> Format[A]): Format[A] = {
     lazy val res: Format[A] = f(using RecursiveFormat.DeferredFormat(() => res))
     res

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveOFormat.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveOFormat.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import scala.annotation.tailrec
+
+trait RecursiveOFormat { self: OFormat.type =>
+  final def recursive[A](f: OFormat[A] ?=> OFormat[A]): OFormat[A] = {
+    lazy val res: OFormat[A] = f(using RecursiveOFormat.DeferredOFormat(() => res))
+    res
+  }
+}
+
+private[json] object RecursiveOFormat {
+  private final case class DeferredOFormat[A](value: () => OFormat[A]) extends OFormat[A] {
+    private lazy val resolved: OFormat[A] = resolve(value)
+
+    @tailrec
+    private def resolve(f: () => OFormat[A]): OFormat[A] =
+      f() match {
+        case DeferredOFormat(f) =>
+          resolve(f)
+        case next =>
+          next
+      }
+
+    override def reads(json: JsValue): JsResult[A] =
+      resolved.reads(json)
+
+    override def writes(o: A): JsObject =
+      resolved.writes(o)
+  }
+}

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveOFormat.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveOFormat.scala
@@ -7,6 +7,19 @@ package play.api.libs.json
 import scala.annotation.tailrec
 
 trait RecursiveOFormat { self: OFormat.type =>
+
+  /**
+   * Constructs an `OFormat` for a recursive type.
+   *
+   * While `f` is evaluated, a deferred `OFormat[A]` is available as a
+   * contextual value. This lets object formats derived inside `f` refer to
+   * the resulting format without forcing it during initialization.
+   *
+   * This method is available only in Scala 3.
+   *
+   * @tparam A the type read from and written as a JSON object
+   * @param f function that constructs the recursive object format
+   */
   final def recursive[A](f: OFormat[A] ?=> OFormat[A]): OFormat[A] = {
     lazy val res: OFormat[A] = f(using RecursiveOFormat.DeferredOFormat(() => res))
     res

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveOWrites.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveOWrites.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import scala.annotation.tailrec
+
+trait RecursiveOWrites { self: OWrites.type =>
+  final def recursive[A](f: OWrites[A] ?=> OWrites[A]): OWrites[A] = {
+    lazy val res: OWrites[A] = f(using RecursiveOWrites.DeferredOWrites(() => res))
+    res
+  }
+}
+
+private[json] object RecursiveOWrites {
+  private final case class DeferredOWrites[A](value: () => OWrites[A]) extends OWrites[A] {
+    private lazy val resolved: OWrites[A] = resolve(value)
+
+    @tailrec
+    private def resolve(f: () => OWrites[A]): OWrites[A] =
+      f() match {
+        case DeferredOWrites(f) =>
+          resolve(f)
+        case next =>
+          next
+      }
+
+    override def writes(o: A): JsObject =
+      resolved.writes(o)
+  }
+}

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveOWrites.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveOWrites.scala
@@ -7,6 +7,19 @@ package play.api.libs.json
 import scala.annotation.tailrec
 
 trait RecursiveOWrites { self: OWrites.type =>
+
+  /**
+   * Constructs an `OWrites` for a recursive type.
+   *
+   * While `f` is evaluated, a deferred `OWrites[A]` is available as a
+   * contextual value. This lets object writers derived inside `f` refer to
+   * the resulting writer without forcing it during initialization.
+   *
+   * This method is available only in Scala 3.
+   *
+   * @tparam A the type written as a JSON object
+   * @param f function that constructs the recursive object writer
+   */
   final def recursive[A](f: OWrites[A] ?=> OWrites[A]): OWrites[A] = {
     lazy val res: OWrites[A] = f(using RecursiveOWrites.DeferredOWrites(() => res))
     res

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveReads.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveReads.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import scala.annotation.tailrec
+
+trait RecursiveReads { self: Reads.type =>
+  final def recursive[A](f: Reads[A] ?=> Reads[A]): Reads[A] = {
+    lazy val res: Reads[A] = f(using RecursiveReads.DeferredReads(() => res))
+    res
+  }
+}
+
+private[json] object RecursiveReads {
+  private final case class DeferredReads[A](value: () => Reads[A]) extends Reads[A] {
+    private lazy val resolved: Reads[A] = resolve(value)
+
+    @tailrec
+    private def resolve(f: () => Reads[A]): Reads[A] =
+      f() match {
+        case DeferredReads(f) =>
+          resolve(f)
+        case next =>
+          next
+      }
+
+    override def reads(json: JsValue): JsResult[A] =
+      resolved.reads(json)
+  }
+}

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveReads.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveReads.scala
@@ -7,6 +7,19 @@ package play.api.libs.json
 import scala.annotation.tailrec
 
 trait RecursiveReads { self: Reads.type =>
+
+  /**
+   * Constructs a `Reads` for a recursive type.
+   *
+   * While `f` is evaluated, a deferred `Reads[A]` is available as a
+   * contextual value. This lets readers derived inside `f` refer to the
+   * resulting reader without forcing it during initialization.
+   *
+   * This method is available only in Scala 3.
+   *
+   * @tparam A the type read from JSON
+   * @param f function that constructs the recursive reader
+   */
   final def recursive[A](f: Reads[A] ?=> Reads[A]): Reads[A] = {
     lazy val res: Reads[A] = f(using RecursiveReads.DeferredReads(() => res))
     res

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveWrites.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveWrites.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import scala.annotation.tailrec
+
+trait RecursiveWrites { self: Writes.type =>
+  final def recursive[A](f: Writes[A] ?=> Writes[A]): Writes[A] = {
+    lazy val res: Writes[A] = f(using RecursiveWrites.DeferredWrites(() => res))
+    res
+  }
+}
+
+private[json] object RecursiveWrites {
+  private final case class DeferredWrites[A](value: () => Writes[A]) extends Writes[A] {
+    private lazy val resolved: Writes[A] = resolve(value)
+
+    @tailrec
+    private def resolve(f: () => Writes[A]): Writes[A] =
+      f() match {
+        case DeferredWrites(f) =>
+          resolve(f)
+        case next =>
+          next
+      }
+
+    override def writes(o: A): JsValue =
+      resolved.writes(o)
+  }
+}

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveWrites.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/RecursiveWrites.scala
@@ -7,6 +7,19 @@ package play.api.libs.json
 import scala.annotation.tailrec
 
 trait RecursiveWrites { self: Writes.type =>
+
+  /**
+   * Constructs a `Writes` for a recursive type.
+   *
+   * While `f` is evaluated, a deferred `Writes[A]` is available as a
+   * contextual value. This lets writers derived inside `f` refer to the
+   * resulting writer without forcing it during initialization.
+   *
+   * This method is available only in Scala 3.
+   *
+   * @tparam A the type written as JSON
+   * @param f function that constructs the recursive writer
+   */
   final def recursive[A](f: Writes[A] ?=> Writes[A]): Writes[A] = {
     lazy val res: Writes[A] = f(using RecursiveWrites.DeferredWrites(() => res))
     res

--- a/play-json/shared/src/main/scala/play/api/libs/json/Format.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Format.scala
@@ -29,7 +29,7 @@ trait OFormat[A] extends OWrites[A] with Reads[A] with Format[A] {
 
 }
 
-object OFormat {
+object OFormat extends RecursiveOFormat {
   implicit def functionalCanBuildFormats(implicit
       rcb: FunctionalCanBuild[Reads],
       wcb: FunctionalCanBuild[OWrites]
@@ -64,7 +64,7 @@ object OFormat {
 /**
  * Default Json formatters.
  */
-object Format extends PathFormat with ConstraintFormat with DefaultFormat {
+object Format extends PathFormat with ConstraintFormat with DefaultFormat with RecursiveFormat {
   val constraints: ConstraintFormat = this
   val path: PathFormat              = this
 

--- a/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
@@ -166,7 +166,8 @@ trait Reads[A] { self =>
 /**
  * Default deserializer type classes.
  */
-object Reads extends ConstraintReads with PathReads with DefaultReads with GeneratedReads {
+object Reads extends ConstraintReads with PathReads with DefaultReads with GeneratedReads with RecursiveReads {
+
   val constraints: ConstraintReads = this
 
   val path: PathReads = this

--- a/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala
@@ -78,7 +78,7 @@ trait OWrites[A] extends Writes[A] {
   override def narrow[B <: A]: OWrites[B] = this.asInstanceOf[OWrites[B]]
 }
 
-object OWrites extends PathWrites with ConstraintWrites {
+object OWrites extends PathWrites with ConstraintWrites with RecursiveOWrites {
   import play.api.libs.functional._
 
   def of[A](implicit w: OWrites[A]): OWrites[A] = w
@@ -237,7 +237,7 @@ object OWrites extends PathWrites with ConstraintWrites {
 /**
  * Default Serializers.
  */
-object Writes extends PathWrites with ConstraintWrites with DefaultWrites with GeneratedWrites {
+object Writes extends PathWrites with ConstraintWrites with DefaultWrites with GeneratedWrites with RecursiveWrites {
   val constraints: ConstraintWrites = this
   val path: PathWrites              = this
 

--- a/play-json/shared/src/test/scala-3/play/api/libs/json/RecursiveSpec.scala
+++ b/play-json/shared/src/test/scala-3/play/api/libs/json/RecursiveSpec.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.libs.json.RecursiveSpec.Foo
+import play.api.libs.functional.syntax.*
+
+final class RecursiveSpec extends AnyWordSpec {
+  "recursive" should {
+    "Reads" in {
+      given Reads[Foo] = Reads.recursive(
+        (
+          (__ \ "x").read[Int] and
+            (__ \ "y").read[List[Foo]]
+        )(Foo.apply)
+      )
+      assert(Foo.json1.as[Foo] == Foo.value1)
+    }
+    "Writes" in {
+      given Writes[Foo] = Writes.recursive(
+        (
+          (__ \ "x").write[Int] and
+            (__ \ "y").write[List[Foo]]
+        )(Tuple.fromProductTyped(_))
+      )
+      assert(Json.toJson(Foo.value1) == Foo.json1)
+    }
+    "OWrites" in {
+      given OWrites[Foo] = OWrites.recursive(
+        (
+          (__ \ "x").write[Int] and
+            (__ \ "y").write[List[Foo]]
+        )(Tuple.fromProductTyped(_))
+      )
+      assert(Json.toJson(Foo.value1) == Foo.json1)
+    }
+    "Format" in {
+      given Format[Foo] = Format.recursive(
+        (
+          (__ \ "x").format[Int] and
+            (__ \ "y").format[List[Foo]]
+        )(Foo.apply, Tuple.fromProductTyped)
+      )
+      assert(Json.toJson(Foo.value1) == Foo.json1)
+      assert(Foo.json1.as[Foo] == Foo.value1)
+    }
+    "OFormat" in {
+      given OFormat[Foo] = OFormat.recursive(
+        (
+          (__ \ "x").format[Int] and
+            (__ \ "y").format[List[Foo]]
+        )(Foo.apply, Tuple.fromProductTyped)
+      )
+      assert(Json.toJson(Foo.value1) == Foo.json1)
+      assert(Foo.json1.as[Foo] == Foo.value1)
+    }
+  }
+}
+
+object RecursiveSpec {
+  private final case class Foo(x: Int, y: List[Foo])
+
+  private object Foo {
+    val value1: Foo = Foo(
+      1,
+      List(
+        Foo(2, Nil),
+        Foo(3, List(Foo(4, Nil))),
+        Foo(5, Nil),
+        Foo(
+          6,
+          List(
+            Foo(7, Nil),
+            Foo(8, Nil)
+          )
+        ),
+      )
+    )
+
+    val json1: JsObject = Json.obj(
+      "x" -> 1,
+      "y" -> Json.arr(
+        Json.obj(
+          "x" -> 2,
+          "y" -> Json.arr()
+        ),
+        Json.obj(
+          "x" -> 3,
+          "y" -> Json.arr(
+            Json.obj(
+              "x" -> 4,
+              "y" -> Json.arr(),
+            )
+          )
+        ),
+        Json.obj(
+          "x" -> 5,
+          "y" -> Json.arr()
+        ),
+        Json.obj(
+          "x" -> 6,
+          "y" -> Json.arr(
+            Json.obj(
+              "x" -> 7,
+              "y" -> Json.arr(),
+            ),
+            Json.obj(
+              "x" -> 8,
+              "y" -> Json.arr(),
+            ),
+          )
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes



## Purpose


Add new `recursive` methods for recursive data types.

- https://circe.io/circe/codecs/recursive-adt.html
- https://github.com/circe/circe/blob/d43edf1475759dfde8b05b6e/docs/codecs/recursive-adt.md
- https://github.com/circe/circe/blob/d43edf1475759dfde8b05b6e/modules/core/shared/src/main/scala/io/circe/Encoder.scala#L170
- https://github.com/typelevel/scalacheck/blob/0d5f3a2afb6c7e04b/core/shared/src/main/scala/org/scalacheck/Gen.scala#L773-L781


## Background Context

`lazyRead`, `lazyWrite` and `lazyFormat` does not work with latest Scala 3.x with `given`.


### Scala 3.8.3

```
Welcome to Scala 3.8.3 (21.0.10, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                                                                 
scala> final case class Foo(x: Int, y: List[Foo])
// defined case class Foo
                                                                                                                                                                                                                 
scala> import play.api.libs.json.*
                                                                                                                                                                                                                 
scala> import play.api.libs.functional.syntax.*
                                                                                                                                                                                                                 
scala> given Reads[Foo] = ((__ \ "x").read[Int] and (__ \ "y").lazyRead(summon[Reads[List[Foo]]]))(Foo.apply)
-- [E172] Type Error: ----------------------------------------------------------
1 |given Reads[Foo] = ((__ \ "x").read[Int] and (__ \ "y").lazyRead(summon[Reads[List[Foo]]]))(Foo.apply)
  |                                                                                         ^
  |No Json deserializer found for type List[Foo]. Try to implement an implicit Reads or Format for this type..
  |I found:
  |
  |    play.api.libs.json.Reads.traversableReads[List, Foo](
  |      scala.collection.immutable.List.iterableFactory[Foo],
  |      /* missing */summon[play.api.libs.json.Reads[Foo]])
  |
  |But no implicit values were found that match type play.api.libs.json.Reads[Foo].
  |
  |One of the following imports might make progress towards fixing the problem:
  |
  |  import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites
  |  import play.api.libs.json.Format.GenericFormat
  |
1 error found
```

### Scala 3.3.7

```
Welcome to Scala 3.3.7 (21.0.10, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                                                                 
scala> final case class Foo(x: Int, y: List[Foo])
// defined case class Foo
                                                                                                                                                                                                                 
scala> import play.api.libs.json.*
                                                                                                                                                                                                                 
scala> import play.api.libs.functional.syntax.*
                                                                                                                                                                                                                 
scala> given Reads[Foo] = ((__ \ "x").read[Int] and (__ \ "y").lazyRead(summon[Reads[List[Foo]]]))(Foo.apply)
lazy val given_Reads_Foo: play.api.libs.json.Reads[Foo]                                                                                                                                                                                                            
```


## References

