### PR TITLE
Handle `TypeBoundsTree` in Scala 3 mirror extraction

### DIFF
--- a/play-json/shared/src/main/scala-3/play/api/libs/json/QuotesHelper.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/QuotesHelper.scala
@@ -274,6 +274,12 @@ private[json] trait QuotesHelper {
               .collect {
                 case TypeDef(
                       n @ ("MirroredElemTypes" | "MirroredElemLabels"),
+                      tt: TypeBoundsTree
+                    ) if tt.tpe <:< TypeRepr.of[Product] =>
+                  n -> tt.tpe
+
+                case TypeDef(
+                      n @ ("MirroredElemTypes" | "MirroredElemLabels"),
                       tt: TypeTree
                     ) if tt.tpe <:< TypeRepr.of[Product] =>
                   n -> tt.tpe


### PR DESCRIPTION
- Fixes #1103

Scala 3.3.4 changed quoted reflection so TypeTree no longer matches TypeBoundsTree. Explicit custom Mirror.Product type aliases such as MirroredElemTypes and MirroredElemLabels can therefore appear as TypeBoundsTree nodes, causing product element extraction to return no fields.

Match TypeBoundsTree before TypeTree so manually provided mirrors keep resolving their element labels and types on current Scala 3.3 releases while preserving the existing TypeTree path.

This finally allows us to upgrade beyond Scala 3.3.3....

Analyzed with the help of codex.

Tested locally: The failing test now passes with Scala 3.3.3, 3.3.4 and latest Scala 3.3.7
For users this isn't really relevant because the generated code always was working, not matter which Scala 3.3,x version is used.