### PR TITLE
Close #1176 - Support Scala3 enum

### DIFF
--- a/play-json/shared/src/main/scala-3/play/api/libs/json/EnumHandler.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/EnumHandler.scala
@@ -59,7 +59,7 @@ private[json] trait EnumHandler {
   inline def enumReads[E <: Enum: Mirror.SumOf](
       insensitive: Boolean = false
   ): Reads[E] = {
-    if (insensitive) {
+    if insensitive then {
       collect[E](EnumHelper.insensitiveValueOf[E])
     } else {
       collect[E](EnumHelper.strictValueOf[E])
@@ -80,7 +80,7 @@ private[json] trait EnumHandler {
   inline def keyEnumReads[E <: Enum: Mirror.SumOf](
       insensitive: Boolean = false
   ): KeyReads[E] = {
-    if (insensitive) {
+    if insensitive then {
       collectKey[E](EnumHelper.insensitiveValueOf[E])
     } else {
       collectKey[E](EnumHelper.strictValueOf[E])

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/EnumHandler.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/EnumHandler.scala
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import scala.util.{ Failure, Success }
+
+import scala.deriving.Mirror
+import scala.reflect.Enum
+
+/**
+ * Utilities to handle [[https://dotty.epfl.ch/docs/reference/enums/enums.html Enumerations]]
+ *
+ * (Inspired by [[https://github.com/lloydmeta/enumeratum/blob/master/enumeratum-reactivemongo-bson/src/main/scala/enumeratum/EnumHandler.scala enumeratum]])
+ */
+private[json] trait EnumHandler {
+
+  /**
+   * Creates a `Reads[A]`, if `A` is a `Enum`,
+   * by resolving at compile-time the `Reads` for the underlying type.
+   *
+   * $macroWarning
+   *
+   * $macroTypeParam
+   *
+   * {{{
+   * import play.api.libs.json.{ Json, Reads }
+   *
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * val r: Reads[Color] = Json.enumReads
+   * // r.reads(JsString("Red")) => JsSuccess(Color.Red)
+   * }}}
+   */
+  inline def enumReads[E <: Enum: Mirror.SumOf]: Reads[E] =
+    collect[E](EnumHelper.strictValueOf[E])
+
+  /**
+   * Creates a `Reads[A]`, if `A` is a `Enum`,
+   * by resolving at compile-time the `Reads` for the underlying type.
+   *
+   * @param insensitive bind in a case-insensitive way, defaults to false
+   *
+   * $macroWarning
+   *
+   * $macroTypeParam
+   *
+   * {{{
+   * import play.api.libs.json.{ Json, Reads }
+   *
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * val r: Reads[Color] = Json.enumReads
+   * }}}
+   */
+  inline def enumReads[E <: Enum: Mirror.SumOf](
+      insensitive: Boolean = false
+  ): Reads[E] = {
+    if (insensitive) {
+      collect[E](EnumHelper.insensitiveValueOf[E])
+    } else {
+      collect[E](EnumHelper.strictValueOf[E])
+    }
+  }
+
+  /**
+   * Returns a strict `KeyReads` for a given enum.
+   */
+  inline def keyEnumReads[E <: Enum: Mirror.SumOf]: KeyReads[E] =
+    collectKey[E](EnumHelper.strictValueOf[E])
+
+  /**
+   * Returns a `KeyReads` for a given enum.
+   *
+   * @param insensitive bind in a case-insensitive way, defaults to false
+   */
+  inline def keyEnumReads[E <: Enum: Mirror.SumOf](
+      insensitive: Boolean = false
+  ): KeyReads[E] = {
+    if (insensitive) {
+      collectKey[E](EnumHelper.insensitiveValueOf[E])
+    } else {
+      collectKey[E](EnumHelper.strictValueOf[E])
+    }
+  }
+
+  /**
+   * Creates a `Reads[A]` for a given enum transformed to lower case,
+   * by resolving at compile-time the `Reads` for the underlying type.
+   *
+   * $macroWarning
+   *
+   * $macroTypeParam
+   *
+   * {{{
+   * import play.api.libs.json.{ Json, Reads }
+   *
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * val r: Reads[Color] = Json.enumReads
+   * }}}
+   */
+  inline def enumReadsLowercaseOnly[E <: Enum: Mirror.SumOf]: Reads[E] =
+    collect[E](EnumHelper.lowerCaseValueOf[E])
+
+  /**
+   * Returns a `KeyReads` for a given enum transformed to lower case.
+   */
+  inline def keyEnumReadsLowercaseOnly[E <: Enum: Mirror.SumOf]: KeyReads[E] =
+    collectKey[E](EnumHelper.lowerCaseValueOf[E])
+
+  /**
+   * Creates a `Reads[A]` for a given enum transformed to upper case,
+   * by resolving at compile-time the `Reads` for the underlying type.
+   *
+   * $macroWarning
+   *
+   * $macroTypeParam
+   *
+   * {{{
+   * import play.api.libs.json.{ Json, Reads }
+   *
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * val r: Reads[Color] = Json.enumReads
+   * }}}
+   */
+  inline def enumReadsUppercaseOnly[E <: Enum: Mirror.SumOf]: Reads[E] =
+    collect[E](EnumHelper.upperCaseValueOf[E])
+
+  /**
+   * Returns a `KeyReads` for a given enum transformed to upper case.
+   */
+  inline def keyEnumReadsUppercaseOnly[E <: Enum: Mirror.SumOf]: KeyReads[E] =
+    collectKey[E](EnumHelper.upperCaseValueOf[E])
+
+  private def collect[E <: Enum](f: String => Option[E]): Reads[E] =
+    Reads[E] {
+      case JsString(str) =>
+        f(str) match {
+          case Some(v) => JsSuccess(v)
+
+          case None => JsError("error.expected.enum")
+        }
+
+      case _ =>
+        JsError("error.expected.string")
+    }
+
+  private def collectKey[E <: Enum](f: String => Option[E]): KeyReads[E] =
+    KeyReads[E] { key =>
+      f(key) match {
+        case Some(v) => JsSuccess(v)
+
+        case None => JsError("error.expected.enum")
+      }
+    }
+
+  /**
+   * Creates a `Writes[T]`, if `A` is a `Enum`, by writing its string representation.
+   *
+   * $macroWarning
+   *
+   * $macroTypeParam
+   *
+   * {{{
+   * import play.api.libs.json.{ Json, Writes }
+   *
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * val w: Writes[Color] = Json.enumWrites
+   *
+   * w.writes(Color.Green) // "Green"
+   * }}}
+   */
+  def enumWrites[E <: Enum]: Writes[E] =
+    Writes[E] { entry => JsString(entry.productPrefix) }
+
+  /**
+   * Returns a `KeyWrites` for a given enum.
+   */
+  def keyEnumWrites[E <: Enum]: KeyWrites[E] = KeyWrites[E](_.productPrefix)
+
+  /**
+   * Creates a `Writes[T]`, if `A` is a `Enum`, by writing it as lower case.
+   *
+   * $macroWarning
+   *
+   * $macroTypeParam
+   *
+   * {{{
+   * import play.api.libs.json.{ Json, Writes }
+   *
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * val w: Writes[Color] = Json.enumWrites
+   *
+   * w.writes(Color.Green) // "Green"
+   * }}}
+   */
+  def enumWritesLowercase[E <: Enum]: Writes[E] =
+    Writes[E] { entry => JsString(entry.productPrefix.toLowerCase) }
+
+  /**
+   * Returns a `KeyWrites` for a given enum, the value as lower case.
+   */
+  def keyEnumWritesLowercase[E <: Enum]: KeyWrites[E] =
+    KeyWrites[E](_.productPrefix.toLowerCase)
+
+  /**
+   * Creates a `Writes[T]`, if `A` is a `Enum`, by writing it as upper case.
+   *
+   * $macroWarning
+   *
+   * $macroTypeParam
+   *
+   * {{{
+   * import play.api.libs.json.{ Json, Writes }
+   *
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * val w: Writes[Color] = Json.enumWrites
+   *
+   * w.writes(Color.Green) // "Green"
+   * }}}
+   */
+  def enumWritesUppercase[E <: Enum]: Writes[E] =
+    Writes[E] { entry => JsString(entry.productPrefix.toUpperCase) }
+
+  /**
+   * Returns a `KeyWrites` for a given enum, the value as upper case.
+   */
+  def keyEnumWritesUppercase[E <: Enum]: KeyWrites[E] =
+    KeyWrites[E](_.productPrefix.toUpperCase)
+
+  /**
+   * Creates a `Format[A]`, if `A` is a `Enum`.
+   *
+   * $macroWarning
+   *
+   * $macroTypeParam
+   *
+   * {{{
+   * import play.api.libs.json.{ Json, Format }
+   *
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * val fmt: Format[Color] = Json.format
+   * }}}
+   */
+  inline def enumFormat[E <: Enum: Mirror.SumOf]: Format[E] =
+    enumFormat[E](false)
+
+  /**
+   * Returns a `Format` for a given enum.
+   *
+   * @param insensitive bind in a case-insensitive way, defaults to false
+   */
+  inline def enumFormat[E <: Enum: Mirror.SumOf](
+      insensitive: Boolean = false
+  ): Format[E] =
+    Format[E](enumReads[E](insensitive), enumWrites[E])
+
+  /**
+   * Returns a `Format` for a given enum,
+   * handling a lower case transformation.
+   */
+  inline def enumFormatLowercaseOnly[E <: Enum: Mirror.SumOf]: Format[E] =
+    Format[E](enumReadsLowercaseOnly[E], enumWritesLowercase[E])
+
+  /**
+   * Returns a `Format` for a given enum,
+   * handling an upper case transformation.
+   */
+  inline def enumFormatUppercaseOnly[E <: Enum: Mirror.SumOf]: Format[E] =
+    Format[E](enumReadsUppercaseOnly[E], enumWritesUppercase[E])
+
+}

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/EnumHelper.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/EnumHelper.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.json
+
+import scala.deriving.Mirror
+import scala.quoted.{ Expr, Quotes, Type }
+import scala.reflect.Enum
+
+/**
+ * Helper about [[https://dotty.epfl.ch/docs/reference/enums/enums.html Enumerations]] string representations.
+ *
+ * (Inspired by [[https://github.com/ReactiveMongo/ReactiveMongo-BSON/blob/master/api/src/main/scala-3/EnumHelper.scala ReactiveMongo-BSON]])
+ */
+object EnumHelper {
+
+  /**
+   * {{{
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * import play.api.libs.json.EnumHelper
+   *
+   * val valueOf: String => Option[Color] = EnumHelper.strictValueOf[Color]
+   *
+   * assert(valueOf("Red") contains Color.Red)
+   * assert(valueOf("red").isEmpty)
+   * }}}
+   */
+  inline def strictValueOf[T <: Enum](using
+      Mirror.SumOf[T]
+  ): String => Option[T] = ${ strictValueOfImpl[T] }
+
+  private def strictValueOfImpl[T <: Enum](using
+      Quotes,
+      Type[T]
+  ): Expr[String => Option[T]] = enumValueOfImpl(identity, None)
+
+  /**
+   * {{{
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * import play.api.libs.json.EnumHelper
+   *
+   * val valueOf: String => Option[Color] = EnumHelper.lowerCaseValueOf[Color]
+   *
+   * assert(valueOf("Red").isEmpty)
+   * assert(valueOf("red") contains Color.Red)
+   * }}}
+   */
+  inline def lowerCaseValueOf[T <: Enum](using
+      Mirror.SumOf[T]
+  ): String => Option[T] = ${ lowerCaseValueOfImpl[T] }
+
+  private def lowerCaseValueOfImpl[T <: Enum](using
+      Quotes,
+      Type[T]
+  ): Expr[String => Option[T]] =
+    enumValueOfImpl((_: String).toLowerCase, None)
+
+  /**
+   * {{{
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * import play.api.libs.json.EnumHelper.upperCaseValueOf
+   *
+   * val valueOf: String => Option[Color] = upperCaseValueOf[Color]
+   *
+   * assert(valueOf("red").isEmpty)
+   * assert(valueOf("RED") contains Color.Red)
+   * }}}
+   */
+  inline def upperCaseValueOf[T <: Enum](using
+      Mirror.SumOf[T]
+  ): String => Option[T] = ${ upperCaseValueOfImpl[T] }
+
+  private def upperCaseValueOfImpl[T <: Enum](using
+      Quotes,
+      Type[T]
+  ): Expr[String => Option[T]] =
+    enumValueOfImpl((_: String).toUpperCase, None)
+
+  /**
+   * {{{
+   * enum Color:
+   *   case Red, Green, Blue
+   *
+   * import play.api.libs.json.EnumHelper
+   *
+   * val valueOf: String => Option[Color] = EnumHelper.insensitiveValueOf[Color]
+   *
+   * assert(valueOf("Red") contains Color.Red)
+   * assert(valueOf("red") contains Color.Red)
+   * assert(valueOf("RED") contains Color.Red)
+   * }}}
+   */
+  inline def insensitiveValueOf[T <: Enum](using
+      Mirror.SumOf[T]
+  ): String => Option[T] = ${ insensitiveValueOfImpl[T] }
+
+  private def insensitiveValueOfImpl[T <: Enum](using
+      Quotes,
+      Type[T]
+  ): Expr[String => Option[T]] =
+    enumValueOfImpl((_: String).toLowerCase, Some('{ (_: String).toLowerCase }))
+
+  private def enumValueOfImpl[T <: Enum](
+      labelNaming: String => String,
+      normalize: Option[Expr[String => String]]
+  )(using
+      q: Quotes,
+      tpe: Type[T]
+  ): Expr[String => Option[T]] = {
+    import q.reflect.*
+
+    val tpr = TypeRepr.of(using tpe)
+
+    val compSym = tpr.typeSymbol.companionModule
+
+    if compSym == Symbol.noSymbol then {
+      report.errorAndAbort(s"Unresolved type: ${tpr.typeSymbol.fullName}")
+    }
+
+    val compRef = Ref(compSym)
+
+    val cases = compSym.fieldMembers
+      .flatMap { fieldSym =>
+        val fieldTerm = compRef.select(fieldSym)
+
+        if fieldTerm.tpe <:< tpr then {
+          Seq(fieldSym -> fieldTerm.asExprOf[T])
+        } else {
+          Seq.empty[(Symbol, Expr[T])]
+        }
+      }
+      .zipWithIndex
+      .map { case ((sym, expr), i) =>
+        val body: Expr[Some[T]] = '{ Some(${ expr }) }
+
+        CaseDef(
+          Literal(StringConstant(labelNaming(sym.name))),
+          guard = None,
+          rhs = body.asTerm
+        )
+      }
+
+    val none = CaseDef(
+      Wildcard(),
+      None,
+      '{ Option.empty[T] }.asTerm
+    )
+
+    def mtch(s: Expr[String]): Expr[Option[T]] = {
+      Match(s.asTerm, cases :+ none).asExprOf[Option[T]]
+    }
+
+    normalize match {
+      case Some(nz) =>
+        '{ (s: String) =>
+          val in = ${ nz }(s)
+
+          ${ mtch('in) }
+        }
+
+      case _ =>
+        '{ (s: String) => ${ mtch('s) } }
+    }
+  }
+}

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/JsMacroImpl.scala
@@ -7,7 +7,7 @@ package play.api.libs.json
 import scala.util.{ Failure as TryFailure, Success as TrySuccess }
 import scala.collection.mutable.Builder as MBuilder
 
-import scala.deriving.Mirror.ProductOf
+import scala.deriving.Mirror.{ ProductOf, SumOf }
 
 import scala.quoted.*
 

--- a/play-json/shared/src/main/scala-3/play/api/libs/json/JsMacros.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/JsMacros.scala
@@ -6,7 +6,9 @@ package play.api.libs.json
 
 import scala.deriving.*
 
-private[json] trait JsMacros {
+import scala.reflect.Enum
+
+private[json] trait JsMacros extends EnumHandler {
 
   /**
    * Creates a `Reads[T]` by resolving, at compile-time,

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -45,16 +45,18 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    * @param index Element index.
    */
   def apply(index: Int): JsValue = result match {
-    case JsDefined(x) =>
-      x match {
+    case JsDefined(defined) =>
+      defined match {
         case arr: JsArray =>
           arr.value.lift(index) match {
-            case Some(x) => x
+            case Some(v) => v
             case None    => throw new IndexOutOfBoundsException(String.valueOf(index))
           }
+
         case _ =>
-          throw new Exception(s"$x is not a JsArray")
+          throw new Exception(s"$defined is not a JsArray")
       }
+
     case x: JsUndefined =>
       throw new Exception(String.valueOf(x.error))
   }
@@ -65,16 +67,18 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
    * @param fieldName Element index.
    */
   def apply(fieldName: String): JsValue = result match {
-    case JsDefined(x) =>
-      x match {
+    case JsDefined(defined) =>
+      defined match {
         case arr: JsObject =>
           arr.underlying.get(fieldName) match {
-            case Some(x) => x
+            case Some(v) => v
             case None    => throw new NoSuchElementException(String.valueOf(fieldName))
           }
+
         case _ =>
-          throw new Exception(s"$x is not a JsObject")
+          throw new Exception(s"$defined is not a JsObject")
       }
+
     case x: JsUndefined =>
       throw new Exception(String.valueOf(x.error))
   }

--- a/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/JsPath.scala
@@ -288,13 +288,15 @@ case class JsPath(path: List[PathNode] = List()) {
         case List(p)      => stepNode(json, p).repath(lpath)
         case head :: tail =>
           head(json) match {
-            case Nil      => JsError(lpath, JsonValidationError("error.path.missing"))
-            case List(js) =>
-              js match {
+            case Nil => JsError(lpath, JsonValidationError("error.path.missing"))
+
+            case List(v) =>
+              v match {
                 case o: JsObject =>
                   step(o, JsPath(tail)).repath(lpath).flatMap(value => filterPathNode(json, head, value))
                 case _ => JsError(lpath, JsonValidationError("error.expected.jsobject"))
               }
+
             case h :: t => JsError(lpath, JsonValidationError("error.path.result.multiple"))
           }
       }

--- a/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
+++ b/play-json/shared/src/main/scala/play/api/libs/json/Reads.scala
@@ -523,23 +523,6 @@ trait DefaultReads extends LowPriorityDefaultReads {
     }
   }
 
-  @scala.annotation.tailrec
-  private def mapObj[K, V](
-      key: String => JsResult[K],
-      in: List[(String, JsValue)],
-      out: Builder[(K, V), Map[K, V]]
-  )(implicit vr: Reads[V]): JsResult[Map[K, V]] = in match {
-    case (k, v) :: entries =>
-      key(k).flatMap(vk => v.validate[V].map(vk -> _)) match {
-        case JsError(details) => JsError(details)
-
-        case JsSuccess((vk, value), _) =>
-          mapObj[K, V](key, entries, out += (vk -> value))
-      }
-
-    case _ => JsSuccess(out.result())
-  }
-
   /** Deserializer for a `Map[K,V]` */
   implicit def mapReads[K, V](k: String => JsResult[K])(implicit fmtv: Reads[V]): Reads[Map[K, V]] = Reads[Map[K, V]] {
     case JsObject(m) => {

--- a/play-json/shared/src/test/scala-3/play/api/libs/json/MacroScala3Spec.scala
+++ b/play-json/shared/src/test/scala-3/play/api/libs/json/MacroScala3Spec.scala
@@ -11,6 +11,7 @@ final class MacroScala3Spec
     extends AnyWordSpec
     with Matchers
     with org.scalatestplus.scalacheck.ScalaCheckPropertyChecks {
+
   "Case class" should {
     "not be handled" when {
       "no custom ProductOf" in {
@@ -57,6 +58,137 @@ final class MacroScala3Spec
       }
     }
   }
+
+  "Enum" should {
+    "be supported with default string representation" when {
+      def readsSpecs(r: Reads[Color]) = {
+        r.reads(JsString("Red")).mustEqual(JsSuccess(Color.Red))
+        r.reads(JsString("Green")).mustEqual(JsSuccess(Color.Green))
+        r.reads(JsString("Blue")).mustEqual(JsSuccess(Color.Blue))
+
+        r.reads(JsString("red")).mustEqual(JsError("error.expected.enum"))
+        r.reads(JsString("GREEN")).mustEqual(JsError("error.expected.enum"))
+        r.reads(JsString("BluE")).mustEqual(JsError("error.expected.enum"))
+      }
+
+      "read" in {
+        readsSpecs(Json.enumReads[Color])
+        readsSpecs(Json.enumReads(insensitive = false))
+      }
+
+      def writesSpecs(w: Writes[Color]) = {
+        w.writes(Color.Red).mustEqual(JsString("Red"))
+        w.writes(Color.Green).mustEqual(JsString("Green"))
+        w.writes(Color.Blue).mustEqual(JsString("Blue"))
+      }
+
+      "write" in {
+        writesSpecs(Json.enumWrites[Color])
+      }
+
+      "format" in {
+        val f: Format[Color] = Json.enumFormat
+
+        readsSpecs(f)
+        readsSpecs(Json.enumFormat(insensitive = false))
+
+        writesSpecs(f)
+      }
+    }
+
+    "be supported with lower case representation" when {
+      def readsSpecs(r: Reads[Color]) = {
+        r.reads(JsString("red")).mustEqual(JsSuccess(Color.Red))
+        r.reads(JsString("green")).mustEqual(JsSuccess(Color.Green))
+        r.reads(JsString("blue")).mustEqual(JsSuccess(Color.Blue))
+
+        r.reads(JsString("Red")).mustEqual(JsError("error.expected.enum"))
+        r.reads(JsString("GREEN")).mustEqual(JsError("error.expected.enum"))
+        r.reads(JsString("BluE")).mustEqual(JsError("error.expected.enum"))
+      }
+
+      "read" in {
+        readsSpecs(Json.enumReadsLowercaseOnly[Color])
+      }
+
+      def writesSpecs(w: Writes[Color]) = {
+        w.writes(Color.Red).mustEqual(JsString("red"))
+        w.writes(Color.Green).mustEqual(JsString("green"))
+        w.writes(Color.Blue).mustEqual(JsString("blue"))
+      }
+
+      "write" in {
+        writesSpecs(Json.enumWritesLowercase[Color])
+      }
+
+      "format" in {
+        val f: Format[Color] = Json.enumFormatLowercaseOnly
+
+        readsSpecs(f)
+        writesSpecs(f)
+      }
+    }
+
+    "be supported with upper case representation" when {
+      def readsSpecs(r: Reads[Color]) = {
+        r.reads(JsString("RED")).mustEqual(JsSuccess(Color.Red))
+        r.reads(JsString("GREEN")).mustEqual(JsSuccess(Color.Green))
+        r.reads(JsString("BLUE")).mustEqual(JsSuccess(Color.Blue))
+
+        r.reads(JsString("Red")).mustEqual(JsError("error.expected.enum"))
+        r.reads(JsString("green")).mustEqual(JsError("error.expected.enum"))
+        r.reads(JsString("BluE")).mustEqual(JsError("error.expected.enum"))
+      }
+
+      "read" in {
+        readsSpecs(Json.enumReadsUppercaseOnly[Color])
+      }
+
+      def writesSpecs(w: Writes[Color]) = {
+        w.writes(Color.Red).mustEqual(JsString("RED"))
+        w.writes(Color.Green).mustEqual(JsString("GREEN"))
+        w.writes(Color.Blue).mustEqual(JsString("BLUE"))
+      }
+
+      "write" in {
+        writesSpecs(Json.enumWritesUppercase[Color])
+      }
+
+      "format" in {
+        val f: Format[Color] = Json.enumFormatUppercaseOnly
+
+        readsSpecs(f)
+        writesSpecs(f)
+      }
+    }
+
+    "ignore case" when {
+      def readsSpecs(r: Reads[Color]) = {
+        r.reads(JsString("Red")).mustEqual(JsSuccess(Color.Red))
+        r.reads(JsString("red")).mustEqual(JsSuccess(Color.Red))
+        r.reads(JsString("RED")).mustEqual(JsSuccess(Color.Red))
+        r.reads(JsString("ReD")).mustEqual(JsSuccess(Color.Red))
+
+        r.reads(JsString("Green")).mustEqual(JsSuccess(Color.Green))
+        r.reads(JsString("green")).mustEqual(JsSuccess(Color.Green))
+        r.reads(JsString("GREEN")).mustEqual(JsSuccess(Color.Green))
+        r.reads(JsString("GrEeN")).mustEqual(JsSuccess(Color.Green))
+
+        r.reads(JsString("Blue")).mustEqual(JsSuccess(Color.Blue))
+        r.reads(JsString("blue")).mustEqual(JsSuccess(Color.Blue))
+        r.reads(JsString("BLUE")).mustEqual(JsSuccess(Color.Blue))
+        r.reads(JsString("BlUE")).mustEqual(JsSuccess(Color.Blue))
+      }
+
+      "read" in {
+        readsSpecs(Json.enumReads(insensitive = true))
+      }
+
+      "format" in {
+        readsSpecs(Json.enumFormat(insensitive = true))
+      }
+    }
+  }
 }
 
 final class CustomNoProductOf(val name: String, val age: Int)
@@ -66,3 +198,6 @@ object CustomNoProductOf {
   given Conversion[CustomNoProductOf, Tuple2[String, Int]] =
     (v: CustomNoProductOf) => v.name -> v.age
 }
+
+enum Color:
+  case Red, Green, Blue

--- a/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/play-json/shared/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -6,14 +6,15 @@ package play.api.libs.json
 
 import play.api.libs.json.JsonNaming.SnakeCase
 
-import play.api.libs.json.Json._
-
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 case class User(age: Int, name: String)
+
 case class Dog(name: String, master: User)
+
 case class UserProfile(firstName: String, lastName: String, zip: Option[String], _homeCity: String)
+
 object UserProfile {
   def obj1  = UserProfile("Christian", "Schmitt", None, "Kenzingen")
   def json1 = Json.obj("first_name" -> "Christian", "last_name" -> "Schmitt", "home_city" -> "Kenzingen")
@@ -25,7 +26,9 @@ object UserProfile {
     )
   def json3 = Json.obj("FirstName" -> "Christian", "LastName" -> "Schmitt", "_homeCity" -> "Kenzingen")
 }
+
 case class UserProfileHolder(holder: String, profile: UserProfile)
+
 case class Cat(name: String)
 
 case class RecUser(
@@ -115,11 +118,9 @@ object CustomApply {
 
 case class Optional(props: Option[String])
 
-class JsonExtensionSpec extends AnyWordSpec with Matchers {
+final class JsonExtensionSpec extends AnyWordSpec with Matchers {
   "JsonExtension" should {
     "create a reads[User]" in {
-      import play.api.libs.json.Json
-
       // object User {def apply(age:Int):User = User(age,"")}
       implicit val userReads: Reads[User] = Json.reads[User]
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

Support [Scala 3 enum](https://dotty.epfl.ch/docs/reference/enums/enums.html) for `Reads`/`Writes`/`Format`.

## Background Context

There is a previous [PR #1176](https://github.com/playframework/play-json/pull/1176).
I think there is another approach about that, more consistent with the existing API/codebase.

- Keep implementation separate from complex macros in `JsMacroImpl`
- Keep API separate in `JsValueMacros` as for Value classes
- Inspired by [enumeratum](https://github.com/lloydmeta/enumeratum/blob/master/enumeratum-reactivemongo-bson/src/main/scala/enumeratum/EnumHandler.scala)
- Inspired by [ReactiveMongo-BSON](https://github.com/ReactiveMongo/ReactiveMongo-BSON/blob/master/api/src/main/scala-3/EnumHelper.scala)

## References

Are there any relevant issues / PRs / mailing lists discussions?

https://github.com/playframework/play-json/pull/1176