### PR TITLE
Avoid deprecated Predef.ArrowAssoc in Scala 3 macro

### DIFF
--- a/play-json/shared/src/main/scala-3/play/api/libs/json/JsMacroImpl.scala
+++ b/play-json/shared/src/main/scala-3/play/api/libs/json/JsMacroImpl.scala
@@ -620,10 +620,10 @@ object JsMacroImpl { // TODO: debug
                           obj
 
                         case jsValue =>
-                          Json.obj("_value" -> jsValue)
+                          Json.obj(("_value", jsValue))
                       }
 
-                      output ++ JsObject(Map(${ config }.discriminator -> JsString(${ tpeCaseName })))
+                      output ++ JsObject(Map((${ config }.discriminator, JsString(${ tpeCaseName }))))
                     }
 
                   case _ =>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

- Fix https://github.com/playframework/play-json/issues/1409

## Purpose


## Background Context


## References

